### PR TITLE
Attempt to fix broken OPGEE dependencies

### DIFF
--- a/py3-opgee-linux.yml
+++ b/py3-opgee-linux.yml
@@ -35,6 +35,8 @@ dependencies:
   - pip:
     - dash-cytoscape>=0.3.0
     - pyXSteam>=0.4.8
-    - thermo==0.2.10    # several tests fail when using v0.2.21
+    - thermo==0.2.25
+    - fluids==1.0.24
+    - chemicals==1.1.4
     - thermosteam>=0.28.12
 

--- a/py3-opgee-linux.yml
+++ b/py3-opgee-linux.yml
@@ -35,6 +35,7 @@ dependencies:
   - pip:
     - dash-cytoscape>=0.3.0
     - pyXSteam>=0.4.8
+    # See https://github.com/CalebBell/thermo/issues/135 for details
     - thermo==0.2.25
     - fluids==1.0.24
     - chemicals==1.1.4

--- a/py3-opgee-macos.yml
+++ b/py3-opgee-macos.yml
@@ -31,5 +31,7 @@ dependencies:
     - dash-cytoscape>=0.3.0
     - nuitka            # moved here because conda version is very outdated
     - pyXSteam>=0.4.8
-    - thermo==0.2.10    # several tests fail when using v0.2.21
+    - thermo==0.2.25
+    - fluids==1.0.24
+    - chemicals==1.1.4
     - thermosteam>=0.28.12

--- a/py3-opgee-macos.yml
+++ b/py3-opgee-macos.yml
@@ -31,6 +31,7 @@ dependencies:
     - dash-cytoscape>=0.3.0
     - nuitka            # moved here because conda version is very outdated
     - pyXSteam>=0.4.8
+    # See https://github.com/CalebBell/thermo/issues/135 for details
     - thermo==0.2.25
     - fluids==1.0.24
     - chemicals==1.1.4

--- a/py3-opgee-travis.yml
+++ b/py3-opgee-travis.yml
@@ -34,6 +34,8 @@ dependencies:
   - pip:
     - dash-cytoscape==0.3.0
     - pyXSteam==0.4.9
-    - thermo==0.2.10
+    - thermo==0.2.25
+    - fluids==1.0.24
+    - chemicals==1.1.4
     - thermosteam==0.30.1
 

--- a/py3-opgee-travis.yml
+++ b/py3-opgee-travis.yml
@@ -34,6 +34,7 @@ dependencies:
   - pip:
     - dash-cytoscape==0.3.0
     - pyXSteam==0.4.9
+    # See https://github.com/CalebBell/thermo/issues/135 for details
     - thermo==0.2.25
     - fluids==1.0.24
     - chemicals==1.1.4

--- a/py3-opgee-win10.yml
+++ b/py3-opgee-win10.yml
@@ -33,7 +33,9 @@ dependencies:
   - sphinxcontrib-serializinghtml
   - urllib3
   - pip:
-    - thermo==0.2.10
+    - thermo==0.2.25
+    - fluids==1.0.24
+    - chemicals==1.1.4
     - thermosteam>=0.28.12
     - pyXSteam>=0.4.8
     - dash-cytoscape>=0.3.0

--- a/py3-opgee-win10.yml
+++ b/py3-opgee-win10.yml
@@ -33,6 +33,7 @@ dependencies:
   - sphinxcontrib-serializinghtml
   - urllib3
   - pip:
+    # See https://github.com/CalebBell/thermo/issues/135 for details
     - thermo==0.2.25
     - fluids==1.0.24
     - chemicals==1.1.4


### PR DESCRIPTION
This PR updates some Conda/pip dependencies to fix a versioning mismatch, see [1], [2] for more details.

Note: I haven't run the tests yet against these versions of dependencies, so I'll leave this as a draft until I do.

[1] https://github.com/CalebBell/thermo/issues/135
[2] https://github.com/Stanford-EAO/OPGEEv4/issues/2