### PR TITLE
Initial support for post-processor plugins

### DIFF
--- a/opgee/built_ins/run_plugin.py
+++ b/opgee/built_ins/run_plugin.py
@@ -102,6 +102,16 @@ class RunCommand(SubcommandABC):
         )
 
         parser.add_argument(
+            "-g",
+            "--post-plugin",
+            metavar="PATH",
+            action="append",
+            help="""Loads the post-processing plugin from the given path. The file
+                    must contain a single, valid subclass of ``opgee.post_process.PostProcess``.
+                    This arg can be specified multiple times to load multiple post-processing
+                    classes. They will be invoked in the order given on the command-line.""")
+
+        parser.add_argument(
             "-i",
             "--ignore-errors",
             action="store_true",
@@ -338,6 +348,11 @@ class RunCommand(SubcommandABC):
             packets = FieldPacket.packetize(
                 model_xml_file, analysis_name, field_names, packet_size
             )
+
+        # Load any (optional) post-processing plugins
+        for path in args.post_plugin:
+            from ..post_processor import PostProcessor
+            PostProcessor.load_plugin(path)
 
         results_list = []
         save_batches = batch_size is not None

--- a/opgee/error.py
+++ b/opgee/error.py
@@ -32,7 +32,7 @@ class AbstractMethodError(OpgeeException):
         self.method = method
 
     def __str__(self):
-        return f"Abstract method {self.method} was called. A subclass of {self.cls.__name__} must implement this method."
+        return f"Abstract method {self.method} was called. Subclass {self.cls.__name__} must implement this method."
 
 
 class AttributeError(OpgeeException):

--- a/opgee/field.py
+++ b/opgee/field.py
@@ -33,6 +33,7 @@ from .error import (
 )
 from .import_export import ImportExport
 from .log import getLogger
+from .post_processor import PostProcessor
 from .process import Process, Aggregator, Reservoir, decache_subclasses
 from .process_groups import ProcessChoice
 from .processes.steam_generator import SteamGenerator
@@ -748,12 +749,8 @@ class Field(Container):
             else [("TOTAL", self.carbon_intensity)] + ci_tuples
         )
 
-        streams = self.streams()
-
-        streams_data = pd.concat([s.to_dataframe() for s in streams])
-
-        # TBD: need to save the streams data to CSV
-        #  =========================================
+        dfs = [s.to_dataframe() for s in self.streams()]
+        streams_data = pd.concat(dfs)
 
         result = FieldResult(
             analysis.name,
@@ -766,6 +763,10 @@ class Field(Container):
             gas_data=gas_data,
             streams_data=streams_data,
         )
+
+        # Run optional post-process plugins
+        PostProcessor.run_post_processors(analysis, self, result)
+
         return result
 
     def get_imported_emissions(self, net_import):

--- a/opgee/manager.py
+++ b/opgee/manager.py
@@ -23,6 +23,7 @@ from .error import McsSystemError, AbstractMethodError
 from .field import FieldResult
 from .log import getLogger, setLogFile
 from .model_file import extract_model
+from .post_processor import PostProcessor
 from .utils import flatten, pushd, mkdirs
 from .mcs.simulation import Simulation, RESULTS_CSV, FAILURES_CSV
 
@@ -477,6 +478,8 @@ def save_results(results, output_dir, batch_num=None):
         df = pd.concat(stream_dfs, axis="rows")
         _to_csv(df, "streams", index=False)
 
+    # Save any results captured by optional post-processor plugins
+    PostProcessor.save_post_processor_results(output_dir)
 
 def _combine_results(filenames, output_name, sort_by=None):
     if not filenames:

--- a/opgee/post_processor.py
+++ b/opgee/post_processor.py
@@ -1,0 +1,63 @@
+#
+# Support for post-processing plugins that run after a Field has been run.
+#
+# Author: Richard Plevin
+# Copyright (c) 2024 the author and RMI
+# See the https://opensource.org/licenses/MIT for license details.
+#
+
+from .analysis import Analysis
+from .core import OpgeeObject, Timer
+from .error import AbstractMethodError
+from .field import Field, FieldResult
+
+class PostProcessor(OpgeeObject):
+    """
+    Abstract base class for post-processing plugins. Subclasses must implement
+    the ``run`` method to perform the post-processing, and they can optionally
+    implement the ``save`` method to save the post-processed data to a file.
+    """
+
+    # Track instances in order defined on the command-line, so we can
+    # run them in the intended sequence
+    instances = []
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def clear(cls):
+        """
+        [Optional method to be implemented by subclasses]
+
+        Clear any state stored in class variables that should not persist between
+        model runs. This describes class variables in the subclasses of
+        ``PostProcessor``: the plugin instances stored here *should* persist.
+
+        :return: nothing
+        """
+        pass
+
+    def run(self, analysis: Analysis, field: Field, results: FieldResult):
+        """
+        [Required method to be implemented by subclasses.]
+
+        Run the desired post-processing.
+
+        :param analysis: (Analysis) the Analysis applied to run the Field
+        :param field: (Field) the Field that was run
+        :param results: (FieldResult) the standard OPGEE results after running
+          the Field.
+        :return: nothing
+        """
+        raise AbstractMethodError(PostProcessor, 'run')
+
+    def save(self):
+        """
+        [Optional method to be implemented by subclasses.]
+
+        Save the data accumulated by this plugin to a file.
+
+        :return: nothing
+        """
+        pass

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -750,7 +750,7 @@ class Process(AttributeMixin, XmlInstantiable):
         :param analysis: (Analysis) the `Analysis` used to retrieve global settings
         :return: None
         """
-        raise AbstractMethodError(Process, 'Process.run')
+        raise AbstractMethodError(self.__class__, 'Process.run')
 
     # TODO: implement mass balance check
     def check_balances(self):

--- a/opgee/utils.py
+++ b/opgee/utils.py
@@ -308,7 +308,7 @@ def loadModuleFromPath(module_path, raiseError=True):
     except KeyError:
         module = None
 
-    _logger.debug(f"Loading module {module_path}")
+    _logger.debug(f"Loading module '{module_path}'")
 
     # Load the compiled code if it's a '.pyc', otherwise load the source code
     try:

--- a/tests/files/broken_post_proc_plugin.py
+++ b/tests/files/broken_post_proc_plugin.py
@@ -1,0 +1,3 @@
+# Test case for class missing a subclass of PostProcessor
+class NotAPlugin():
+    pass

--- a/tests/files/simple_post_processor.py
+++ b/tests/files/simple_post_processor.py
@@ -1,0 +1,22 @@
+import os
+
+from opgee.post_processor import PostProcessor
+
+class SimplePostProcessor(PostProcessor):
+    results = []
+
+    def __init__(self):
+        pass
+
+    @classmethod
+    def clear(cls):
+        cls.results.clear()
+
+    def run(self, analysis, field, result):
+        self.results.append(('dummy-data', result))
+
+    def save(self, output_dir):
+        path = os.path.join(output_dir, 'simple_post_processor.csv')
+        with open(path, 'w') as f:
+            for tag, value in self.results:
+                f.write(f"{tag}, {value}\n")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,7 +23,7 @@ def test_dict_from_list_error():
         dict_from_list(items)
 
 def test_from_xml_error():
-    with pytest.raises(AbstractMethodError, match=f"Abstract method XmlInstantiable.from_xml was called. A subclass of XmlInstantiable must implement this method."):
+    with pytest.raises(AbstractMethodError, match=f"Abstract method XmlInstantiable.from_xml was called.*"):
         XmlInstantiable("foo").from_xml(None)
 
 def test_find_parent_error():

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,5 +1,6 @@
 from opgee import ureg
-from opgee.energy import Energy, EN_DIESEL, EN_NATURAL_GAS, EN_RESID, EN_PETCOKE, EN_CRUDE_OIL
+from opgee.energy import (Energy, EN_DIESEL, EN_NATURAL_GAS, EN_RESID,
+                          EN_PETCOKE, EN_CRUDE_OIL, EN_ELECTRICITY)
 from opgee.error import OpgeeException
 import pytest
 
@@ -8,6 +9,17 @@ def test_set_rate():
     rate = ureg.Quantity(123.45, 'mmbtu/day')
     e.set_rate(EN_DIESEL, rate)
     assert e.data[EN_DIESEL] == rate
+
+def test_set_electricity():
+    e = Energy()
+    rate = ureg.Quantity(123.45, 'kWh/day')
+    e.set_rate(EN_ELECTRICITY, rate)
+
+    # Though set as "kWh/day", value is stored as "mmBtu/day", after conversion
+    as_set = e.get_rate(EN_ELECTRICITY)
+    assert as_set.u == Energy._units
+
+    assert e.data[EN_ELECTRICITY] == rate
 
 def test_set_rates_error():
     """Test that an unknown carrier name throws an OpgeeException"""

--- a/tests/test_post_proc_plugin.py
+++ b/tests/test_post_proc_plugin.py
@@ -1,0 +1,63 @@
+import pytest
+
+from opgee.analysis import Analysis
+from opgee.constants import DETAILED_RESULT
+from opgee.error import AbstractMethodError
+from opgee.field import Field, FieldResult
+from opgee.post_processor import PostProcessor
+
+from .utils_for_tests import load_test_model, path_to_test_file
+
+@pytest.fixture(scope="function")
+def test_model2(configure_logging_for_tests):
+    # This fixture also serves to test user classpath
+    model = load_test_model('test_model2.xml', class_path=path_to_test_file('user_processes.py'))
+    return model
+
+DATA = 'dummy_data'
+
+class SimplePostProcessor(PostProcessor):
+    results = []
+    def __init__(self):
+        pass
+
+    @classmethod
+    def clear(cls):
+        cls.results.clear()
+
+    def run(self, analysis: Analysis, field: Field, result: FieldResult):
+        self.results.append((DATA, result))
+
+    def save(self):
+        pass
+
+def test_simple_post_processor(test_model2):
+    analysis = test_model2.get_analysis('Analysis1')
+    field = test_model2.get_field('Field1')
+    result = FieldResult(analysis.name, field.name, DETAILED_RESULT)
+
+    instance = SimplePostProcessor()
+    instance.run(analysis, field, result)
+
+    assert len(instance.results) == 1
+
+    saved = instance.results[0]
+    assert saved[0] == DATA and saved[1] == result
+
+    SimplePostProcessor.clear()
+    assert len(SimplePostProcessor.results) == 0
+
+
+class InvalidPostProcessor(PostProcessor):
+    # Doesn't define required run() method
+    pass
+
+def test_invalid_post_processor(test_model2):
+    analysis = test_model2.get_analysis('Analysis1')
+    field = test_model2.get_field('Field1')
+    result = FieldResult(analysis.name, field.name, DETAILED_RESULT)
+
+    instance = InvalidPostProcessor()
+
+    with pytest.raises(AbstractMethodError):
+        instance.run(analysis, field, result)

--- a/tests/test_post_proc_plugin.py
+++ b/tests/test_post_proc_plugin.py
@@ -1,12 +1,13 @@
+import os
 import pytest
 
 from opgee.analysis import Analysis
 from opgee.constants import DETAILED_RESULT
-from opgee.error import AbstractMethodError
+from opgee.error import AbstractMethodError, McsUserError
 from opgee.field import Field, FieldResult
 from opgee.post_processor import PostProcessor
 
-from .utils_for_tests import load_test_model, path_to_test_file
+from .utils_for_tests import load_test_model, path_to_test_file, tempdir
 
 @pytest.fixture(scope="function")
 def test_model2(configure_logging_for_tests):
@@ -14,38 +15,32 @@ def test_model2(configure_logging_for_tests):
     model = load_test_model('test_model2.xml', class_path=path_to_test_file('user_processes.py'))
     return model
 
-DATA = 'dummy_data'
-
-class SimplePostProcessor(PostProcessor):
-    results = []
-    def __init__(self):
-        pass
-
-    @classmethod
-    def clear(cls):
-        cls.results.clear()
-
-    def run(self, analysis: Analysis, field: Field, result: FieldResult):
-        self.results.append((DATA, result))
-
-    def save(self):
-        pass
-
 def test_simple_post_processor(test_model2):
     analysis = test_model2.get_analysis('Analysis1')
     field = test_model2.get_field('Field1')
     result = FieldResult(analysis.name, field.name, DETAILED_RESULT)
 
-    instance = SimplePostProcessor()
-    instance.run(analysis, field, result)
+    PostProcessor.decache()
 
-    assert len(instance.results) == 1
+    path = path_to_test_file('simple_post_processor.py')
+    plugin = PostProcessor.load_plugin(path)
 
-    saved = instance.results[0]
-    assert saved[0] == DATA and saved[1] == result
+    PostProcessor.run_post_processors(analysis, field, result)
 
-    SimplePostProcessor.clear()
-    assert len(SimplePostProcessor.results) == 0
+    assert len(plugin.results) == 1
+
+    pair = plugin.results[0]
+    assert pair[0] == 'dummy-data' and pair[1] == result
+
+    output_dir = os.path.dirname(path)
+    PostProcessor.save_post_processor_results(output_dir)
+
+    csv_file = os.path.join(output_dir, 'simple_post_processor.csv')
+    assert os.path.exists(csv_file)
+    os.remove(csv_file)
+
+    # prior results are cleared after saving
+    assert len(plugin.results) == 0
 
 
 class InvalidPostProcessor(PostProcessor):
@@ -57,7 +52,46 @@ def test_invalid_post_processor(test_model2):
     field = test_model2.get_field('Field1')
     result = FieldResult(analysis.name, field.name, DETAILED_RESULT)
 
+    # class is missing run() method
     instance = InvalidPostProcessor()
 
     with pytest.raises(AbstractMethodError):
         instance.run(analysis, field, result)
+
+def test_missing_plugin():
+    path = path_to_test_file('MISSING-FILE.py')
+
+    with pytest.raises(McsUserError, match=r"Path to plugin '.*' does not exist"):
+        PostProcessor.load_plugin(path)
+
+def test_missing_subclass():
+    path = path_to_test_file('broken_post_proc_plugin.py')
+
+    with pytest.raises(McsUserError, match=r'No subclass of PostProcessor .*'):
+        PostProcessor.load_plugin(path)
+
+def test_cmd_line_post_proc(opgee_main):
+    PostProcessor.decache()
+    plugin_path = path_to_test_file('simple_post_processor.py')
+    xml_path = path_to_test_file('test_run_subcmd.xml')
+
+    with tempdir() as output_dir:
+        args = [
+            'run',
+            '-m', xml_path,
+            '-a', 'test',
+            '--no-default-model',
+            '--cluster-type=serial',
+            '--output-dir', output_dir,
+            '--post-plugin', plugin_path,
+        ]
+        print("opg ", ' '.join(args))
+
+        opgee_main.run(None, args)
+
+        inst = PostProcessor.instances
+        assert len(inst) == 1
+        assert inst[0].__class__.__name__ == 'SimplePostProcessor'
+
+        csv_file = os.path.join(output_dir, 'simple_post_processor.csv')
+        assert os.path.exists(csv_file)

--- a/tests/test_run_subcmd.py
+++ b/tests/test_run_subcmd.py
@@ -1,22 +1,10 @@
-from contextlib import contextmanager
 from glob import glob
 import os
 import pytest
 from opgee.config import setParam, pathjoin
 from opgee.error import CommandlineError
 from opgee.tool import opg
-from .utils_for_tests import path_to_test_file
-
-@contextmanager
-def tempdir():
-    import tempfile
-    import shutil
-
-    d = tempfile.mkdtemp()
-    try:
-        yield d
-    finally:
-        shutil.rmtree(d)
+from .utils_for_tests import path_to_test_file, tempdir
 
 def test_missing_output_dir(opgee_main):
     name = 'test'

--- a/tests/utils_for_tests.py
+++ b/tests/utils_for_tests.py
@@ -1,7 +1,19 @@
+from contextlib import contextmanager
 from io import StringIO
 from opgee.config import pathjoin, getParam, setParam, readConfigFile
 from opgee.model_file import ModelFile
 from opgee.process import Process
+
+@contextmanager
+def tempdir():
+    import tempfile
+    import shutil
+
+    d = tempfile.mkdtemp()
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d)
 
 class ProcA(Process):
     def run(self, analysis):


### PR DESCRIPTION
Support for new PostProcessor plugin class, command-line arg to indicate file with plugin, and test file that exercises it all.

We may need to refine the API depending on use cases, e.g., we might want to set plugins via config file to simplify cmdline usage.