### PR TITLE
Clean documentation and code

### DIFF
--- a/opgee/energy.py
+++ b/opgee/energy.py
@@ -72,8 +72,7 @@ class Energy(OpgeeObject):
         Get the rate of energy use for a single carrier
 
         :param carrier: (str) one of the defined energy carriers (values of Energy.carriers)
-        :return: (float) the rate of use (e.g., mmbtu/day (LHV) for all but electricity,
-            which is in units of kWh/day.
+        :return: (float) the rate of use for all energy sources in mmbtu/day (LHV), except for electricity, which is in mmbtu/day without LHV (no combustion to thermal energy), assuming 100% mechanical to thermal energy conversion.
         """
         if carrier not in self._carrier_set:
             raise OpgeeException(f"Energy.set_rate: Unrecognized carrier '{carrier}'")
@@ -85,8 +84,7 @@ class Energy(OpgeeObject):
         Set the rate of energy use for a single carrier.
 
         :param carrier: (str) one of the defined energy carriers (values of Energy.carriers)
-        :param rate: (float) the rate of use (e.g., mmbtu/day (LHV) for all but electricity,
-            which is in units of kWh/day.
+        :param rate: (float) the rate of use for all energy sources in mmbtu/day (LHV), except for electricity, which is in mmbtu/day without LHV (no combustion to thermal energy), assuming 100% mechanical to thermal energy conversion.
         :return: none
         """
         if carrier not in self._carrier_set:
@@ -109,8 +107,7 @@ class Energy(OpgeeObject):
         Add to the rate of energy use for a single carrier.
 
         :param carrier: (str) one of the defined energy carriers (values of Energy.carriers)
-        :param rate: (float) the increment in rate of use (e.g., mmbtu/day (LHV) for all but
-            electricity, which is in units of kWh/day.
+        :param rate: (float) the increment  rate of use for all energy sources in mmbtu/day (LHV), except for electricity, which is in mmbtu/day without LHV (no combustion to thermal energy), assuming 100% mechanical to thermal energy conversion.
         :return: none
         """
         if carrier not in self._carrier_set:

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -18,7 +18,7 @@ from .config import getParamAsBoolean
 from .container import Container
 from .core import OpgeeObject, XmlInstantiable, elt_name, instantiate_subelts, magnitude
 from .emissions import Emissions
-from .energy import Energy
+from .energy import EN_ELECTRICITY, Energy
 from .error import OpgeeException, AbstractMethodError, OpgeeIterationConverged, ModelValidationError
 from .import_export import ImportExport
 from .log import getLogger
@@ -394,6 +394,19 @@ class Process(AttributeMixin, XmlInstantiable):
             and the GHG value computed using the model's current GWP settings.
         """
         return self.emissions.rates(gwp=analysis.gwp)
+    
+    def compute_emission_combustion(self)->float:
+        """
+        Compute the total emissions from the combustion of all energy carriers,
+        excluding electricity.
+
+        :return: (float) the total combustion emissions calculated by multiplying
+                the energy used (excluding electricity) by the process emission
+                factor and summing the result.
+        """
+        energy_for_combustion = self.energy.data.drop(EN_ELECTRICITY)
+        combustion_emission : float = (energy_for_combustion * self.process_EF).sum()
+        return combustion_emission
 
     def add_energy_rate(self, carrier, rate):
         """

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -367,7 +367,7 @@ class Process(AttributeMixin, XmlInstantiable):
 
         :param category: (str) one of the defined emissions categories
         :param gas: (str) one of the defined emissions (values of Emissions.emissions)
-        :param rate: (float) the increment in rate in the Process' flow units (e.g., mmbtu (LHV) of fuel burned)
+        :param rate: (float) the increment in rate in the Process' flow units (e.g., mmbtu/day (LHV) of fuel burned) except for electricity, which is in mmbtu/day as well but without LHV (no combustion to thermal energy), assuming 100% mechanical to thermal energy conversion.
         :return: none
         """
         self.emissions.add_rate(category, gas, rate)
@@ -400,8 +400,7 @@ class Process(AttributeMixin, XmlInstantiable):
         Set the rate of energy use for a single carrier.
 
         :param carrier: (str) one of the defined energy carriers (values of Energy.carriers)
-        :param rate: (float) the rate of use (e.g., mmbtu/day (LHV) for all but electricity,
-            which is in units of kWh/day.
+        :param rate: (float)  the rate of use for all energy sources in mmbtu/day (LHV), except for electricity, which is in mmbtu/day as well but without LHV (no combustion to thermal energy), assuming 100% mechanical to thermal energy conversion.
         :return: none
         """
         self.energy.add_rate(carrier, rate)

--- a/opgee/processes/CO2_membrane.py
+++ b/opgee/processes/CO2_membrane.py
@@ -86,7 +86,6 @@ class CO2Membrane(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/CO2_membrane.py
+++ b/opgee/processes/CO2_membrane.py
@@ -86,6 +86,5 @@ class CO2Membrane(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        
         combustion_emission = self.compute_emission_combustion()
         self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/CO2_reinjection_compressor.py
+++ b/opgee/processes/CO2_reinjection_compressor.py
@@ -94,9 +94,7 @@ class CO2ReinjectionCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/LNG_regasification.py
+++ b/opgee/processes/LNG_regasification.py
@@ -53,10 +53,8 @@ class LNGRegasification(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
 
 

--- a/opgee/processes/LNG_transport.py
+++ b/opgee/processes/LNG_transport.py
@@ -61,7 +61,5 @@ class LNGTransport(Process):
         import_product.set_export(self.name, NGL_LPG, gas_LHV_rate)
 
         # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/VRU_compressor.py
+++ b/opgee/processes/VRU_compressor.py
@@ -75,9 +75,7 @@ class VRUCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/acid_gas_removal.py
+++ b/opgee/processes/acid_gas_removal.py
@@ -202,7 +202,6 @@ class AcidGasRemoval(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        
         combustion_emission = self.compute_emission_combustion()
         self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
         self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/acid_gas_removal.py
+++ b/opgee/processes/acid_gas_removal.py
@@ -202,12 +202,10 @@ class AcidGasRemoval(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop(EN_ELECTRICITY)
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
 
 
     def calculate_energy_consumption_from_Aspen(self, input, output_gas, mol_frac_CO2, mol_frac_H2S):

--- a/opgee/processes/bitumen_mining.py
+++ b/opgee/processes/bitumen_mining.py
@@ -148,9 +148,7 @@ class BitumenMining(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/crude_oil_dewatering.py
+++ b/opgee/processes/crude_oil_dewatering.py
@@ -109,7 +109,5 @@ class CrudeOilDewatering(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/crude_oil_stabilization.py
+++ b/opgee/processes/crude_oil_stabilization.py
@@ -131,9 +131,8 @@ class CrudeOilStabilization(Process):
         self.set_import_from_energy(energy_use)
 
         # emission rate
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/crude_oil_transport.py
+++ b/opgee/processes/crude_oil_transport.py
@@ -71,6 +71,5 @@ class CrudeOilTransport(Process):
         field.import_export.set_export(self.name, CRUDE_OIL, oil_LHV_rate)
 
         # emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
+        combustion_emission = self.compute_emission_combustion()
         self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/demethanizer.py
+++ b/opgee/processes/demethanizer.py
@@ -230,7 +230,6 @@ class Demethanizer(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        
         combustion_emission = self.compute_emission_combustion()
         self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 

--- a/opgee/processes/demethanizer.py
+++ b/opgee/processes/demethanizer.py
@@ -11,6 +11,7 @@ import pandas as pd
 from .. import ureg
 from ..core import STP, TemperaturePressure
 from ..emissions import EM_COMBUSTION, EM_FUGITIVES
+from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process
 from ..process import run_corr_eqns
@@ -223,7 +224,7 @@ class Demethanizer(Process):
         energy_carrier = get_energy_carrier(self.prime_mover_type)
         energy_use.set_rate(energy_carrier,
                             inlet_compressor_energy_consump + outlet_compressor_energy_consump + reboiler_fuel_use)
-        energy_use.set_rate("Electricity", cooler_energy_consumption)
+        energy_use.set_rate(EN_ELECTRICITY, cooler_energy_consumption)
 
         # import/export
         self.set_import_from_energy(energy_use)

--- a/opgee/processes/demethanizer.py
+++ b/opgee/processes/demethanizer.py
@@ -230,9 +230,8 @@ class Demethanizer(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/downhole_pump.py
+++ b/opgee/processes/downhole_pump.py
@@ -206,13 +206,11 @@ class DownholePump(Process):
 
             # import and export
             self.set_import_from_energy(energy_use)
-        # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        # emissions
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
 
     def impute(self):
         field = self.field

--- a/opgee/processes/drilling.py
+++ b/opgee/processes/drilling.py
@@ -110,11 +110,10 @@ class Drilling(Process):
         energy_use = self.energy
         energy_use.set_rate(EN_DIESEL, diesel_consumption)
 
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-        emissions.set_rate(EM_LAND_USE, "CO2", land_use_emission)
+        # emissions
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        self.emissions.set_rate(EM_LAND_USE, "CO2", land_use_emission)
 
     def get_fracture_constant(self):
         """

--- a/opgee/processes/exploration.py
+++ b/opgee/processes/exploration.py
@@ -127,7 +127,6 @@ class Exploration(Process):
         energy_use = self.energy
         energy_use.set_rate(EN_DIESEL, diesel_consumption)
 
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        # emissions
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/gas_dehydration.py
+++ b/opgee/processes/gas_dehydration.py
@@ -166,12 +166,10 @@ class GasDehydration(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
 
     @staticmethod
     def pseudo_pressure(tau, Tc_over_T, critical_pressure):

--- a/opgee/processes/gas_lifting_compressor.py
+++ b/opgee/processes/gas_lifting_compressor.py
@@ -77,9 +77,7 @@ class GasLiftingCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/gas_reinjection_compressor.py
+++ b/opgee/processes/gas_reinjection_compressor.py
@@ -89,9 +89,7 @@ class GasReinjectionCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/heavy_oil_dilution.py
+++ b/opgee/processes/heavy_oil_dilution.py
@@ -20,9 +20,9 @@ class HeavyOilDilution(Process):
         self.water_density = self.water.density()
 
         model = self.model
-        self.transport_share_fuel = model.transport_share_fuel.loc["Diluent"]
-        self.transport_parameter = model.transport_parameter[["Diluent", "Units"]]
-        self.transport_by_mode = model.transport_by_mode.loc["Diluent"]
+        self.transport_share_fuel = model.transport_share_fuel.loc[DILUENT]
+        self.transport_parameter = model.transport_parameter[[DILUENT, "Units"]]
+        self.transport_by_mode = model.transport_by_mode.loc[DILUENT]
 
         self.before_diluent_tp = None
         self.bitumen_tp = None
@@ -85,7 +85,7 @@ class HeavyOilDilution(Process):
             input_liquid_volume_rate / (1 - frac_diluent)
         required_volume_diluent = expected_volume_oil_bitumen * frac_diluent
 
-        if self.dilution_type == "Diluent":
+        if self.dilution_type == DILUENT:
             required_mass_dilution = required_volume_diluent * self.dilution_SG * self.water_density
             total_mass_diluted_oil = required_mass_dilution + input_liquid_mass_rate
             diluent_LHV = field.oil.mass_energy_density(API=self.diluent_API)
@@ -117,7 +117,7 @@ class HeavyOilDilution(Process):
                                                                             self.transport_share_fuel,
                                                                             self.transport_by_mode,
                                                                             diluent_energy_rate,
-                                                                            "Diluent")
+                                                                            DILUENT)
 
         energy_use = self.energy
         for name, value in fuel_consumption.items():

--- a/opgee/processes/heavy_oil_dilution.py
+++ b/opgee/processes/heavy_oil_dilution.py
@@ -129,7 +129,5 @@ class HeavyOilDilution(Process):
         import_product.set_export(self.name, DILUENT, diluent_energy_rate)
 
         # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/heavy_oil_upgrading.py
+++ b/opgee/processes/heavy_oil_upgrading.py
@@ -190,8 +190,7 @@ class HeavyOilUpgrading(Process):
         field.import_export.set_export(self.name, H2, proc_gas_to_H2_mass_rate.sum() + NG_to_H2_mass_rate.sum())
 
         # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-        emissions.set_from_series(EM_FLARING, proc_gas_flaring_mass_rate.pint.to("tonne/day"))
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+
+        self.emissions.set_from_series(EM_FLARING, proc_gas_flaring_mass_rate.pint.to("tonne/day"))

--- a/opgee/processes/heavy_oil_upgrading.py
+++ b/opgee/processes/heavy_oil_upgrading.py
@@ -12,6 +12,7 @@ from .. import ureg
 from ..core import STP
 from ..emissions import EM_COMBUSTION, EM_FLARING
 from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_UPG_PROC_GAS, EN_PETCOKE
+from ..import_export import ELECTRICITY, H2
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS
@@ -185,8 +186,8 @@ class HeavyOilUpgrading(Process):
 
         # import/export
         self.set_import_from_energy(energy_use)
-        field.import_export.set_export(self.name, "Electricity", elect_cogen)
-        field.import_export.set_export(self.name, "H2", proc_gas_to_H2_mass_rate.sum() + NG_to_H2_mass_rate.sum())
+        field.import_export.set_export(self.name, ELECTRICITY, elect_cogen)
+        field.import_export.set_export(self.name, H2, proc_gas_to_H2_mass_rate.sum() + NG_to_H2_mass_rate.sum())
 
         # emission
         emissions = self.emissions

--- a/opgee/processes/petrocoke_transport.py
+++ b/opgee/processes/petrocoke_transport.py
@@ -67,7 +67,5 @@ class PetrocokeTransport(Process):
         import_product.set_export(self.name, NGL_LPG, petrocoke_LHV_rate)
 
         # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/opgee/processes/post_storage_compressor.py
+++ b/opgee/processes/post_storage_compressor.py
@@ -69,8 +69,7 @@ class PostStorageCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/pre_membrane_compressor.py
+++ b/opgee/processes/pre_membrane_compressor.py
@@ -63,9 +63,7 @@ class PreMembraneCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/ryan_holmes.py
+++ b/opgee/processes/ryan_holmes.py
@@ -91,9 +91,7 @@ class RyanHolmes(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/separation.py
+++ b/opgee/processes/separation.py
@@ -117,12 +117,10 @@ class Separation(Process):
         self.set_import_from_energy(energy_use)
 
         # emission rate
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
 
     def impute(self):
         field = self.field

--- a/opgee/processes/sour_gas_compressor.py
+++ b/opgee/processes/sour_gas_compressor.py
@@ -69,12 +69,10 @@ class SourGasCompressor(Process):
         self.set_import_from_energy(energy_use)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
 
 
 

--- a/opgee/processes/steam_generation.py
+++ b/opgee/processes/steam_generation.py
@@ -183,10 +183,9 @@ class SteamGeneration(Process):
         import_product = field.import_export
         import_product.set_export(self.name, EN_ELECTRICITY, electricity_HRSG)
 
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        # emissions
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
 
     def get_feedwater_horsepower(self, prod_water_mass_rate, makeup_water_mass_rate):
         prod_water_volume_rate = prod_water_mass_rate / self.water_density

--- a/opgee/processes/storage_compressor.py
+++ b/opgee/processes/storage_compressor.py
@@ -68,8 +68,7 @@ class StorageCompressor(Process):
         gas_to_well.subtract_rates_from(gas_fugitives)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -110,8 +110,7 @@ class TransmissionCompressor(Process):
         gas_to_distribution.subtract_rates_from(gas_to_liquefaction)
 
         # emissions
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
-        emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+
+        self.emissions.set_from_stream(EM_FUGITIVES, gas_fugitives)

--- a/opgee/processes/water_injection.py
+++ b/opgee/processes/water_injection.py
@@ -114,7 +114,5 @@ class WaterInjection(Process):
         self.set_import_from_energy(energy_use)
 
         # emission
-        emissions = self.emissions
-        energy_for_combustion = energy_use.data.drop("Electricity")
-        combustion_emission = (energy_for_combustion * self.process_EF).sum()
-        emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)
+        combustion_emission = self.compute_emission_combustion()
+        self.emissions.set_rate(EM_COMBUSTION, "CO2", combustion_emission)

--- a/tests/test_table_manager.py
+++ b/tests/test_table_manager.py
@@ -1,11 +1,12 @@
 import pytest
+from opgee.energy import EN_NATURAL_GAS, EN_NGL
 from opgee.error import OpgeeException
 from opgee.table_manager import TableManager
 from .utils_for_tests import path_to_test_file
 
 def test_updates(test_model):
     df = test_model.upstream_CI
-    assert df.loc['NGL', 'EF'].m == 1234.5 and df.loc['Natural gas', 'EF'].m == 12345.67
+    assert df.loc[EN_NGL, 'EF'].m == 1234.5 and df.loc[EN_NATURAL_GAS, 'EF'].m == 12345.67
 
 def test_add_table():
     table_name = 'test_table'


### PR DESCRIPTION
This pull request changes the documentation on the unit of electricity energy carriers https://github.com/msmasnadi/OPGEEv4/issues/22 and then tries to remove the hard-coded strings for readdibility of the code https://github.com/msmasnadi/OPGEEv4/issues/14. Then I decided to solve this issue of redundant factors because the hard-coded strings was used in that part https://github.com/msmasnadi/OPGEEv4/issues/17.

The CO2 string is used multiples times across the code maybe it could be great to create a constant variables for it. 