### PR TITLE
Rename stream contents

### DIFF
--- a/docs/source/guidelines.rst
+++ b/docs/source/guidelines.rst
@@ -75,7 +75,7 @@ principles:
 2. **Keep stream contents as generic as possible.** |br|
    Avoid names that encode the endpoints of the stream, using instead as generic a name
    for the contents as possible. Use content names that describe the main contents of the
-   stream, like "crude oil" or "dehydrated gas". **Do not** include the name of the source or
+   stream, like "oil" or "dehydrated gas". **Do not** include the name of the source or
    destination processes in the contents.
 
 3. **Store data that needs to be shared with other processes in the Field instance.** |br|

--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -678,7 +678,7 @@
 		</Stream>
 
 		<Stream src="ProductionBoundary" dst="TransmissionCompressor">
-			<Contains>gas for transmission</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary">
@@ -714,15 +714,15 @@
         </Stream>
 
         <Stream src="StorageCompressor" dst="StorageWell">
-            <Contains>gas for well</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="StorageWell" dst="StorageSeparator">
-            <Contains>gas for separator</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="StorageSeparator" dst="PostStorageCompressor">
-            <Contains>gas for storage</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="PostStorageCompressor" dst="GasDistribution">
@@ -730,7 +730,7 @@
         </Stream>
 
         <Stream src="LNGLiquefaction" dst="LNGTransport">
-            <Contains>gas for transport</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="LNGTransport" dst="LNGRegasification">

--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -530,7 +530,7 @@
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="WaterTreatment">
-			<Contains>recycled water</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 
@@ -622,7 +622,7 @@
 		</Stream>
 
 		<Stream src="CO2ReinjectionCompressor" dst="CO2InjectionWell">
-			<Contains>gas for CO2 injection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="CO2InjectionWell" dst="GasPartition">
@@ -670,11 +670,11 @@
 		</Stream>
 
 		<Stream src="GasReinjectionCompressor" dst="GasReinjectionWell">
-			<Contains>gas for gas reinjection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasReinjectionWell" dst="Reservoir" impute="false">
-			<Contains>gas for reservoir</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="ProductionBoundary" dst="TransmissionCompressor">

--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -383,21 +383,21 @@
 		</Stream>
 
 		<Stream src="Reservoir" dst="ReservoirWellInterface">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream src="ReservoirWellInterface" dst="DownholePump">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream src="DownholePump" dst="Separation">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 
 <!--		After separation-->
 		<Stream src="Separation" dst="CrudeOilDewatering">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream src="Separation" dst="WaterTreatment">
@@ -438,7 +438,7 @@
 		</Stream>
 
 		<Stream src="CrudeOilStabilization" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="HeavyOilDilution" dst="CrudeOilStorage">
@@ -513,20 +513,20 @@
 
 <!--		water processing path-->
 		<Stream src="WaterTreatment" dst="ProductionBoundary">
-			<Contains>water for surface disposal</Contains>
+			<Contains>water</Contains>
 			<Contains>water for subsurface disposal</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="SteamGeneration" name="produced water treatment">
-			<Contains>produced water for steam generation</Contains>
+			<Contains>produced water</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="SteamGeneration" name="makeup water treatment">
-			<Contains>makeup water for steam generation</Contains>
+			<Contains>makeup water</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="WaterInjection">
-			<Contains>water for water injection</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="WaterTreatment">
@@ -550,11 +550,11 @@
 		</Stream>
 
 		<Stream src="Venting" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="VRUCompressor" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasGathering" dst="GasDehydration">
@@ -578,11 +578,11 @@
 		</Stream>
 
 		<Stream src="PreMembraneChiller" dst="PreMembraneCompressor">
-			<Contains>gas for compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="PreMembraneCompressor" dst="CO2Membrane">
-			<Contains>gas for CO2 membrane</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="CO2Membrane" dst="AcidGasRemoval">
@@ -634,7 +634,7 @@
 		</Stream>
 
 		<Stream src="SourGasCompressor" dst="SourGasInjection">
-			<Contains>gas for sour gas injection</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="SourGasInjection" dst="GasPartition">
@@ -666,7 +666,7 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="GasReinjectionCompressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasReinjectionCompressor" dst="GasReinjectionWell">
@@ -682,7 +682,7 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 
 		<Stream src="NGL" dst="ProductionBoundary">

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -537,7 +537,7 @@ class Process(AttributeMixin, XmlInstantiable):
         Stream, list, dict]:
         """
         Find the input or output streams (indicated by `direction`) that contain the indicated
-        `stream_type`, e.g., 'crude oil', 'raw water' and so on.
+        `stream_type`, e.g., 'oil', 'water' and so on.
 
         :param direction: (str) 'input' or 'output'
         :param stream_type: (str) the generic type of stream a process can handle.
@@ -593,7 +593,7 @@ class Process(AttributeMixin, XmlInstantiable):
     def find_input_stream(self, stream_type, raiseError=True) -> Union[Stream, None]:
         """
         Find exactly one input stream connected to a downstream Process that produces the indicated
-        `stream_type`, e.g., 'crude oil', 'raw water' and so on.
+        `stream_type`, e.g., 'oil', 'water' and so on.
 
         :param stream_type: (str) the generic type of stream a process can handle.
         :param raiseError: (bool) whether to raise an error if no handlers of `stream_type` are found.
@@ -611,7 +611,7 @@ class Process(AttributeMixin, XmlInstantiable):
     def find_output_stream(self, stream_type, raiseError=True) -> Union[Stream, None]:
         """
         Find exactly one output stream connected to a downstream Process that consumes the indicated
-        `stream_type`, e.g., 'crude oil', 'raw water' and so on.
+        `stream_type`, e.g., 'oil', 'water' and so on.
 
         :param stream_type: (str) the generic type of stream a process can handle.
         :param raiseError: (bool) whether to raise an error if no handlers of `stream_type` are found.

--- a/opgee/processes/CO2_injection_well.py
+++ b/opgee/processes/CO2_injection_well.py
@@ -18,17 +18,17 @@ class CO2InjectionWell(Process):
         This process models a injection well used for injecting CO2 into the reservoir.
 
         input streams:
-            - gas for CO2 injection well: gas stream with CO2 for injection
+            - gas: gas stream with CO2 for injection
 
         output streams:
-            - gas for reservoir: gas stream with CO2 injected into reservoir
+            - gas for gas partition: gas stream with CO2 injected into reservoir
     """
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for CO2 injection well",
+            "gas",
         ]
 
         self._required_outputs = [
@@ -40,7 +40,7 @@ class CO2InjectionWell(Process):
         field = self.field
 
         # Get input stream and check if it's initialized
-        input = self.find_input_stream("gas for CO2 injection well")
+        input = self.find_input_stream("gas")
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/CO2_membrane.py
+++ b/opgee/processes/CO2_membrane.py
@@ -21,7 +21,7 @@ class CO2Membrane(Process):
     This process represents the separation of CO2 from natural gas using a membrane.
 
     input streams:
-        - gas for CO2 membrane
+        - gas
 
     output streams:
         - gas for AGR
@@ -32,9 +32,10 @@ class CO2Membrane(Process):
         super().__init__(name, **kwargs)
 
         self._required_inputs = [
-            "gas for CO2 membrane",         # TODO: avoid process names in contents.
+            "gas",
         ]
 
+        # TODO: avoid process names in contents.
         self._required_outputs = [
             "gas for AGR",
             "gas for CO2 compressor",
@@ -60,7 +61,7 @@ class CO2Membrane(Process):
         self.print_running_msg()
         field = self.field
 
-        input = self.find_input_stream("gas for CO2 membrane")
+        input = self.find_input_stream("gas")
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/CO2_reinjection_compressor.py
+++ b/opgee/processes/CO2_reinjection_compressor.py
@@ -24,7 +24,7 @@ class CO2ReinjectionCompressor(Process):
         - gas for CO2 compressor: The inlet stream of CO2 gas to the compressor.
 
         Outputs:
-        - gas for CO2 injection well: The outlet stream of CO2 gas that is reinjected into the reservoir.
+        - gas: The outlet stream of CO2 gas that is reinjected into the reservoir.
 
         Attributes:
         - res_press: The reservoir pressure in psia.
@@ -41,7 +41,7 @@ class CO2ReinjectionCompressor(Process):
         ]
 
         self._required_outputs = [
-            "gas for CO2 injection well",
+            "gas",
         ]
 
         self.res_press = None
@@ -86,7 +86,7 @@ class CO2ReinjectionCompressor(Process):
             total_energy_consumption += energy_consumption
 
         # Set output stream and iteration value
-        gas_to_well = self.find_output_stream("gas for CO2 injection well")
+        gas_to_well = self.find_output_stream("gas")
         gas_to_well.copy_flow_rates_from(input)
         gas_to_well.subtract_rates_from(gas_fugitives)
         gas_to_well.tp.set(T=out_temp, P=discharge_press)

--- a/opgee/processes/LNG_liquefaction.py
+++ b/opgee/processes/LNG_liquefaction.py
@@ -23,9 +23,8 @@ class LNGLiquefaction(Process):
             "LNG",
         ]
 
-        # TODO: avoid process names in contents.
         self._required_outputs = [
-            "gas for transport",
+            "gas",
             # "gas fugitives"       # TODO: future feature
         ]
 
@@ -52,7 +51,7 @@ class LNGLiquefaction(Process):
         # TODO: delete unused code here and below
         # total_load = (self.compression_refrigeration_load + self.ancillary_loads) * self.NG_to_liq_rate
 
-        gas_to_transport = self.find_output_stream("gas for transport")
+        gas_to_transport = self.find_output_stream("gas")
         gas_to_transport.copy_flow_rates_from(input)
         gas_to_transport.tp.set(T=self.field.LNG_temp)
 

--- a/opgee/processes/LNG_transport.py
+++ b/opgee/processes/LNG_transport.py
@@ -22,9 +22,8 @@ class LNGTransport(Process):
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
-        # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for transport",
+            "gas",
         ]
 
         self._required_outputs = [
@@ -39,7 +38,7 @@ class LNGTransport(Process):
         self.print_running_msg()
         field = self.field
 
-        input = self.find_input_stream("gas for transport")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return

--- a/opgee/processes/VRU_compressor.py
+++ b/opgee/processes/VRU_compressor.py
@@ -34,7 +34,7 @@ class VRUCompressor(Process):
         ]
 
         self._required_outputs = [
-            "gas for gas gathering"
+            "gas"
         ]
 
         self.discharge_press = None
@@ -59,7 +59,7 @@ class VRUCompressor(Process):
         loss_rate = self.venting_fugitive_rate()
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_gathering = self.find_output_stream("gas for gas gathering")
+        gas_to_gathering = self.find_output_stream("gas")
 
         overall_compression_ratio = self.discharge_press / input.tp.P
         energy_consumption, output_temp, output_press = \

--- a/opgee/processes/crude_oil_dewatering.py
+++ b/opgee/processes/crude_oil_dewatering.py
@@ -19,7 +19,8 @@ _logger = getLogger(__name__)
 
 class CrudeOilDewatering(Process):
     """
-        A subclass of the Process class that represents a crude oil dewatering process in an oil and gas production system.
+        A subclass of the Process class that represents a crude oil dewatering process
+        in an oil and gas production system.
 
         Attributes:
             field (Field): The field associated with the dewatering process.
@@ -38,7 +39,7 @@ class CrudeOilDewatering(Process):
         self.oil_path = self.field.oil_path
 
         # TODO: avoid process names in contents. Can all the subsequent processes just
-        #  look for "crude oil"? Then we'd have a single output stream.
+        #  look for "oil"? Then we'd have a single output stream.
         self.oil_path_dict = {"Stabilization": "oil for stabilization",
                               "Storage": "oil for storage",
                               "Upgrading": "oil for upgrading",
@@ -46,7 +47,7 @@ class CrudeOilDewatering(Process):
                               "Dilution and Upgrading": "oil for dilution"}
 
         self._required_inputs = [
-            "crude oil",
+            "oil",
         ]
 
         self._required_outputs = [
@@ -75,7 +76,7 @@ class CrudeOilDewatering(Process):
         self.print_running_msg()
 
         # mass rate
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/crude_oil_stabilization.py
+++ b/opgee/processes/crude_oil_stabilization.py
@@ -42,7 +42,7 @@ class CrudeOilStabilization(Process):
         ]
 
         self._required_outputs = [
-            "gas for gas gathering",
+            "gas",
             "oil for storage",
         ]
 
@@ -101,7 +101,7 @@ class CrudeOilStabilization(Process):
         gas_removed_molar_rate = gas_removed_by_stabilizer * self.mol_per_scf * oil.gas_comp  # Pandas Series
         gas_removed_mass_rate = oil.component_MW[gas_removed_molar_rate.index] * gas_removed_molar_rate
 
-        output_stab_gas = self.find_output_stream("gas for gas gathering")
+        output_stab_gas = self.find_output_stream("gas")
         gas_tp_after_separation = field.get_process_data("gas_tp_after_separation")
         if gas_tp_after_separation is None:
             gas_tp_after_separation = input.tp

--- a/opgee/processes/downhole_pump.py
+++ b/opgee/processes/downhole_pump.py
@@ -66,12 +66,12 @@ class DownholePump(Process):
         super().__init__(name, **kwargs)
 
         self._required_inputs = [
-            "crude oil",
+            "oil",
             # "lifting gas", # optional input stream
         ]
 
         self._required_outputs = [
-            "crude oil",
+            "oil",
         ]
 
         self.gravitational_acceleration = self.field.model.const("gravitational-acceleration")
@@ -113,7 +113,7 @@ class DownholePump(Process):
         field = self.field
 
         # mass rate
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         if input.is_uninitialized():
             return
 
@@ -124,7 +124,7 @@ class DownholePump(Process):
         loss_rate = field.component_fugitive_table[self.name]
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        output = self.find_output_stream("crude oil")
+        output = self.find_output_stream("oil")
         output.copy_flow_rates_from(input, tp=self.wellhead_tp)
         output.subtract_rates_from(gas_fugitives)
 
@@ -223,7 +223,7 @@ class DownholePump(Process):
 
     def impute(self):
         field = self.field
-        output = self.find_output_stream("crude oil")
+        output = self.find_output_stream("oil")
 
         loss_rate = field.component_fugitive_table[self.name]
         loss_rate = (1 / (1 - loss_rate)).to("frac")
@@ -238,7 +238,7 @@ class DownholePump(Process):
         completion_workover_fugitive_stream.set_rates_from_series(completion_workover_fugitive_series, phase=PHASE_GAS)
         field.save_process_data(completion_workover_fugitive_stream=completion_workover_fugitive_stream)
 
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         input.copy_flow_rates_from(output)
         input.multiply_flow_rates(loss_rate)
         input.add_flow_rates_from(completion_workover_fugitive_stream)

--- a/opgee/processes/gas_gathering.py
+++ b/opgee/processes/gas_gathering.py
@@ -22,7 +22,7 @@ class GasGathering(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for gas gathering"
+            "gas"
         ]
 
         self._required_outputs = [
@@ -49,11 +49,11 @@ class GasGathering(Process):
         self.print_running_msg()
         field = self.field
 
-        if not self.all_streams_ready("gas for gas gathering"):
+        if not self.all_streams_ready("gas"):
             return
 
         # mass_rate
-        input = self.find_input_streams("gas for gas gathering", combine=True)
+        input = self.find_input_streams("gas", combine=True)
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/gas_partition.py
+++ b/opgee/processes/gas_partition.py
@@ -38,11 +38,11 @@ class GasPartition(Process):
 
         self._required_outputs = [
             "gas",
-            # also two possible output streams below
+            # also two possible output streams below: "lifting gas" and "exported gas"
         ]
 
         if field.natural_gas_reinjection:
-            self._required_outputs.append("gas for gas reinjection compressor")
+            self._required_outputs.append("gas")
 
         if field.gas_lifting:
             self._required_outputs.append("lifting gas")
@@ -185,9 +185,7 @@ class GasPartition(Process):
                 exported_gas_stream.subtract_rates_from(reinjected_HC_stream)
                 exported_gas_stream.subtract_rates_from(fuel_stream)
 
-            gas_to_reinjection = self.find_output_stream(
-                "gas for gas reinjection compressor"
-            )
+            gas_to_reinjection = self.find_output_stream("gas")
             combined_gas_stream = reinjected_HC_stream
             if field.get_process_data("gas_flooding_stream") is not None:
                 gas_flooding_stream = field.get_process_data("gas_flooding_stream")
@@ -202,7 +200,7 @@ class GasPartition(Process):
                 )
             )
 
-        exported_gas = self.find_output_stream("gas")
+        exported_gas = self.find_output_stream("exported gas")
         if field.get_process_data("is_input_from_well") is None:
             exported_gas.copy_flow_rates_from(exported_gas_stream)
 
@@ -225,7 +223,7 @@ class GasPartition(Process):
         gas etc.).
 
         If the reinjected gas stream has a non-zero total flow rate, the flow rates are copied
-        to the gas for gas reinjection compressor.
+        to the gas for the reinjection compressor.
 
         :param import_product: (ImportProduct) import product object
         :param reinjected_gas_stream: (Stream) gas stream being reinjected into the reservoir
@@ -338,8 +336,6 @@ class GasPartition(Process):
                     self.name, NATURAL_GAS, imported_NG_energy_rate
                 )
 
-        gas_to_reinjection = self.find_output_stream(
-            "gas for gas reinjection compressor"
-        )
+        gas_to_reinjection = self.find_output_stream("gas")
         if reinjected_gas_stream.total_flow_rate().m != 0:
             gas_to_reinjection.copy_flow_rates_from(reinjected_gas_stream)

--- a/opgee/processes/gas_reinjection_compressor.py
+++ b/opgee/processes/gas_reinjection_compressor.py
@@ -23,7 +23,7 @@ class GasReinjectionCompressor(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for gas reinjection compressor"
+            "gas"
         ]
 
         self._required_outputs = [
@@ -59,7 +59,7 @@ class GasReinjectionCompressor(Process):
         field = self.field
 
         # TODO: unclear how this can work if the input stream doesn't exist
-        input = self.find_input_stream("gas for gas reinjection compressor", raiseError=False)
+        input = self.find_input_stream("gas", raiseError=False)
 
         if input is None or input.is_uninitialized():
             return

--- a/opgee/processes/gas_reinjection_compressor.py
+++ b/opgee/processes/gas_reinjection_compressor.py
@@ -21,13 +21,12 @@ class GasReinjectionCompressor(Process):
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
-        # TODO: avoid process names in contents.
         self._required_inputs = [
             "gas"
         ]
 
         self._required_outputs = [
-            "gas for gas reinjection well"
+            "gas"
         ]
 
         self.air_separation_energy_intensity = None
@@ -67,7 +66,7 @@ class GasReinjectionCompressor(Process):
         loss_rate = self.get_compressor_and_well_loss_rate(input)
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_well = self.find_output_stream("gas for gas reinjection well")
+        gas_to_well = self.find_output_stream("gas")
         gas_to_well.copy_flow_rates_from(input)
         gas_to_well.subtract_rates_from(gas_fugitives)
 

--- a/opgee/processes/gas_reinjection_well.py
+++ b/opgee/processes/gas_reinjection_well.py
@@ -19,11 +19,11 @@ class GasReinjectionWell(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for gas reinjection well"
+            "gas"
         ]
 
         self._required_outputs = [
-            "gas for reservoir",
+            "gas",
         ]
 
         self.gas_flooding = None
@@ -44,7 +44,7 @@ class GasReinjectionWell(Process):
         self.print_running_msg()
 
         # mass rate
-        input = self.find_input_stream("gas for gas reinjection well")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return
@@ -52,7 +52,7 @@ class GasReinjectionWell(Process):
         loss_rate = self.get_compressor_and_well_loss_rate(input)
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_reservoir = self.find_output_stream("gas for reservoir")
+        gas_to_reservoir = self.find_output_stream("gas")
         gas_to_reservoir.copy_flow_rates_from(input)
         gas_to_reservoir.subtract_rates_from(gas_fugitives)
 

--- a/opgee/processes/post_storage_compressor.py
+++ b/opgee/processes/post_storage_compressor.py
@@ -21,11 +21,11 @@ class PostStorageCompressor(Process):
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
-        # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for storage",
+            "gas",
         ]
 
+        # TODO: avoid process names in contents.
         self._required_outputs = [
             "gas for distribution",
         ]
@@ -45,7 +45,7 @@ class PostStorageCompressor(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas for storage")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return

--- a/opgee/processes/pre_membrane_chiller.py
+++ b/opgee/processes/pre_membrane_chiller.py
@@ -25,7 +25,7 @@ class PreMembraneChiller(Process):
         ]
 
         self._required_outputs = [
-            "gas for compressor",
+            "gas",
         ]
 
         self.compressor_load = ureg.Quantity(3.44, "kW")
@@ -49,7 +49,7 @@ class PreMembraneChiller(Process):
         loss_rate = self.venting_fugitive_rate()
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_compressor = self.find_output_stream("gas for compressor")
+        gas_to_compressor = self.find_output_stream("gas")
         gas_to_compressor.copy_flow_rates_from(input)
         gas_to_compressor.subtract_rates_from(gas_fugitives)
         gas_to_compressor.tp.set(T=self.outlet_temp, P=input.tp.P)

--- a/opgee/processes/pre_membrane_compressor.py
+++ b/opgee/processes/pre_membrane_compressor.py
@@ -22,11 +22,11 @@ class PreMembraneCompressor(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for compressor",
+            "gas",
         ]
 
         self._required_outputs = [
-            "gas for CO2 membrane",
+            "gas",
         ]
 
         self.discharge_press = None
@@ -42,7 +42,7 @@ class PreMembraneCompressor(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas for compressor")
+        input = self.find_input_stream("gas")
         if input.is_uninitialized():
             return
 
@@ -50,7 +50,7 @@ class PreMembraneCompressor(Process):
         loss_rate = min(ureg.Quantity(0.95, "frac"), loss_rate)
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_CO2_membrane = self.find_output_stream("gas for CO2 membrane")
+        gas_to_CO2_membrane = self.find_output_stream("gas")
         gas_to_CO2_membrane.copy_flow_rates_from(input)
         gas_to_CO2_membrane.subtract_rates_from(gas_fugitives)
         self.set_iteration_value(gas_to_CO2_membrane.total_flow_rate())

--- a/opgee/processes/reservoir_well_interface.py
+++ b/opgee/processes/reservoir_well_interface.py
@@ -22,11 +22,11 @@ class ReservoirWellInterface(Process):
         super().__init__(name, **kwargs)
 
         self._required_inputs = [
-            "crude oil",
+            "oil",
         ]
 
         self._required_outputs = [
-            "crude oil",
+            "oil",
         ]
 
         self.frac_CO2_breakthrough = None
@@ -55,13 +55,13 @@ class ReservoirWellInterface(Process):
         field = self.field
 
         # mass rate
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         if input.is_uninitialized():
             return
 
         input.set_tp(self.res_tp)
 
-        output = self.find_output_stream("crude oil")
+        output = self.find_output_stream("oil")
         output.copy_flow_rates_from(input)
 
         CO2_flooding_rate = field.get_process_data("CO2_flooding_rate_init")
@@ -77,9 +77,9 @@ class ReservoirWellInterface(Process):
         output.tp.set(T=self.res_tp.T, P=bottomhole_flowing_press)
 
     def impute(self):
-        output = self.find_output_stream("crude oil")
+        output = self.find_output_stream("oil")
 
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         input.copy_flow_rates_from(output)
 
     def get_bottomhole_press(self, input_stream):

--- a/opgee/processes/separation.py
+++ b/opgee/processes/separation.py
@@ -24,7 +24,7 @@ class Separation(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "crude oil",
+            "oil",
         ]
 
         self._required_outputs = [
@@ -93,7 +93,7 @@ class Separation(Process):
         water_oil_ratio = field.attr("WOR")
 
         # mass rate
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
 
         loss_rate = field.component_fugitive_table[self.name]
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
@@ -139,7 +139,7 @@ class Separation(Process):
         loss_rate = (1 / (1 - loss_rate)).to("frac")
         output.multiply_flow_rates(loss_rate)
 
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         input.copy_flow_rates_from(output, tp=field.wellhead_tp)
         oil_LHV_rate = oil.energy_flow_rate(input)
         gas_LHV_rate = field.gas.energy_flow_rate(input)
@@ -176,7 +176,7 @@ class Separation(Process):
         gas_after.set_rates_from_series(gas_mass_rate, PHASE_GAS)
         gas_after.tp.set(T=self.outlet_tp.T, P=self.pressure_after_boosting)
 
-        oil_after = self.find_output_stream("crude oil")
+        oil_after = self.find_output_stream("oil")
         oil_mass_rate = (self.oil_volume_rate * density).to("tonne/day")
         water_in_oil_mass_rate = self.water_in_oil_mass_rate(oil_mass_rate)
         oil_after.set_liquid_flow_rate("oil", oil_mass_rate)

--- a/opgee/processes/sour_gas_compressor.py
+++ b/opgee/processes/sour_gas_compressor.py
@@ -26,7 +26,7 @@ class SourGasCompressor(Process):
         ]
 
         self._required_outputs = [
-            "gas for sour gas injection",
+            "gas",
         ]
 
         self.eta_compressor = None
@@ -52,7 +52,7 @@ class SourGasCompressor(Process):
         loss_rate = self.get_compressor_and_well_loss_rate(input)
         gas_fugitives = self.set_gas_fugitives(input, loss_rate)
 
-        gas_to_injection = self.find_output_stream("gas for sour gas injection")
+        gas_to_injection = self.find_output_stream("gas")
         gas_to_injection.copy_flow_rates_from(input)
         gas_to_injection.subtract_rates_from(gas_fugitives)
 

--- a/opgee/processes/sour_gas_injection.py
+++ b/opgee/processes/sour_gas_injection.py
@@ -19,7 +19,7 @@ class SourGasInjection(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for sour gas injection",
+            "gas",
         ]
 
         self._required_outputs = [
@@ -31,7 +31,7 @@ class SourGasInjection(Process):
         field = self.field
 
         # mass rate
-        input = self.find_input_stream("gas for sour gas injection")
+        input = self.find_input_stream("gas")
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/steam_generation.py
+++ b/opgee/processes/steam_generation.py
@@ -38,7 +38,7 @@ class SteamGeneration(Process):
             ]
 
             self._required_outputs = [
-                "recycled water",
+                "water",
             ]
         else:
             self._required_inputs = []
@@ -145,7 +145,7 @@ class SteamGeneration(Process):
 
         recycled_blowdown_water = blowdown_water_mass_rate * self.fraction_blowdown_recycled
 
-        recycled_water_stream = self.find_output_stream("recycled water")
+        recycled_water_stream = self.find_output_stream("water")
         recycled_water_stream.set_liquid_flow_rate("H2O",
                                                    recycled_blowdown_water.to("tonne/day"),
                                                    tp=self.waste_water_reinjection_tp)

--- a/opgee/processes/steam_generation.py
+++ b/opgee/processes/steam_generation.py
@@ -33,9 +33,8 @@ class SteamGeneration(Process):
         field = self.field
         if field.steam_flooding == 1 and field.SOR != 0:
             self._required_inputs = [
-                # TODO: avoid process names in contents.
-                "produced water for steam generation",
-                "makeup water for steam generation"
+                "produced water",
+                "makeup water"
             ]
 
             self._required_outputs = [
@@ -122,8 +121,8 @@ class SteamGeneration(Process):
 
         # mass rate
 
-        input_prod_water = self.find_input_stream("produced water for steam generation")
-        input_makeup_water = self.find_input_stream("makeup water for steam generation")
+        input_prod_water = self.find_input_stream("produced water")
+        input_makeup_water = self.find_input_stream("makeup water")
         if input_prod_water.is_uninitialized() and input_makeup_water.is_uninitialized():
             return
 

--- a/opgee/processes/storage_compressor.py
+++ b/opgee/processes/storage_compressor.py
@@ -29,7 +29,7 @@ class StorageCompressor(Process):
         ]
 
         self._required_outputs = [
-            "gas for well",
+            "gas",
         ]
 
         self.discharge_press = None
@@ -71,7 +71,7 @@ class StorageCompressor(Process):
         # import/export
         self.set_import_from_energy(energy_use)
 
-        gas_to_well = self.find_output_stream("gas for well")
+        gas_to_well = self.find_output_stream("gas")
         gas_to_well.copy_flow_rates_from(input, phase=PHASE_GAS)
         gas_to_well.tp.set(T=output_temp, P=self.discharge_press)
         gas_to_well.subtract_rates_from(gas_fugitives)

--- a/opgee/processes/storage_separator.py
+++ b/opgee/processes/storage_separator.py
@@ -21,13 +21,12 @@ class StorageSeparator(Process):
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
-        # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for separator",
+            "gas",
         ]
 
         self._required_outputs = [
-            "gas for storage",
+            "gas",
         ]
 
         self.water_production_frac = None
@@ -41,7 +40,7 @@ class StorageSeparator(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas for separator")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return
@@ -50,7 +49,7 @@ class StorageSeparator(Process):
         prod_water = Stream("produced water stream", self.outlet_tp)
         prod_water.set_liquid_flow_rate("H2O", (input.total_gas_rate() * self.water_production_frac).m)
 
-        gas_to_compressor = self.find_output_stream("gas for storage")
+        gas_to_compressor = self.find_output_stream("gas")
         gas_to_compressor.copy_gas_rates_from(input, tp=self.outlet_tp)
 
         #TODO: Future versions of OPGEE may treat this process in more detail.

--- a/opgee/processes/storage_well.py
+++ b/opgee/processes/storage_well.py
@@ -21,13 +21,12 @@ class StorageWell(Process):
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
-        # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for well",
+            "gas",
         ]
 
         self._required_outputs = [
-            "gas for separator",
+            "gas",
         ]
 
         self.cache_attributes()
@@ -38,14 +37,14 @@ class StorageWell(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas for well")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return
 
         gas_fugitives = self.set_gas_fugitives(input, self.loss_rate)
 
-        gas_to_separator = self.find_output_stream("gas for separator")
+        gas_to_separator = self.find_output_stream("gas")
         gas_to_separator.copy_gas_rates_from(input)
         gas_to_separator.subtract_rates_from(gas_fugitives)
 

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -26,7 +26,7 @@ class TransmissionCompressor(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "gas for transmission",
+            "gas",
         ]
 
         self._required_outputs = [
@@ -63,7 +63,7 @@ class TransmissionCompressor(Process):
     def run(self, analysis):
         self.print_running_msg()
 
-        input = self.find_input_stream("gas for transmission")
+        input = self.find_input_stream("gas")
 
         if input.is_uninitialized():
             return

--- a/opgee/processes/venting.py
+++ b/opgee/processes/venting.py
@@ -26,7 +26,7 @@ class Venting(Process):
         ]
 
         self._required_outputs = [
-            "gas for gas gathering",
+            "gas",
         ]
 
         self.imported_fuel_gas_comp = field.imported_gas_comp["Imported Fuel"]
@@ -95,7 +95,7 @@ class Venting(Process):
 
         gas_fugitives = self.set_gas_fugitives(input, fugitive_frac.to("frac").m)
 
-        gas_to_gathering = self.find_output_stream("gas for gas gathering")
+        gas_to_gathering = self.find_output_stream("gas")
         gas_tp_after_separation = field.get_process_data("gas_tp_after_separation")
         gas_to_gathering.copy_flow_rates_from(input, tp=gas_tp_after_separation)
         gas_to_gathering.subtract_rates_from(gas_to_vent)

--- a/opgee/processes/water_injection.py
+++ b/opgee/processes/water_injection.py
@@ -39,7 +39,7 @@ class WaterInjection(Process):
 
         # TODO: avoid process names in contents.
         self._required_inputs = [
-            "water for water injection",
+            "water",
         ]
 
         self._required_outputs = []
@@ -89,7 +89,7 @@ class WaterInjection(Process):
         if self.num_water_inj_wells.m == 0:
             raise OpgeeException(f"Got zero number of injector in the {self.name} process")
 
-        input = self.find_input_stream("water for water injection")
+        input = self.find_input_stream("water")
         if input.is_uninitialized():
             return
 

--- a/opgee/processes/water_treatment.py
+++ b/opgee/processes/water_treatment.py
@@ -34,18 +34,17 @@ class WaterTreatment(Process):
             "water",
         ]
 
-        # TODO: avoid process names in contents.
         self._required_outputs = []
 
         field = self.field
         if field.steam_flooding:
             self._required_outputs.extend([
-                "makeup water for steam generation",
-                "produced water for steam generation",
+                "makeup water",
+                "produced water",
             ])
 
         if field.water_flooding or field.water_reinjection:
-            self._required_outputs.append("water for water injection")
+            self._required_outputs.append("water")
 
         self.water_treatment_table = self.model.water_treatment
 
@@ -139,14 +138,14 @@ class WaterTreatment(Process):
             min(injected_steam_mass_demand, input_water_mass_rate - prod_water_mass)
 
         if self.steam_flooding:
-            makeup_water_to_steam = self.find_output_stream("makeup water for steam generation")
-            prod_water_to_steam = self.find_output_stream("produced water for steam generation")
+            makeup_water_to_steam = self.find_output_stream("makeup water")
+            prod_water_to_steam = self.find_output_stream("produced water")
             prod_water_to_steam.set_liquid_flow_rate("H2O", prod_steam_mass.to("tonne/day"), tp=input.tp)
             if makeup_steam_mass.m != 0:
                 makeup_water_to_steam.set_liquid_flow_rate("H2O", makeup_steam_mass.to("tonne/day"),
                                                            tp=self.makeup_water_tp)
         if self.water_flooding or self.water_reinjection:
-            water_to_reinjection = self.find_output_stream("water for water injection")
+            water_to_reinjection = self.find_output_stream("water")
             water_to_reinjection_rate = prod_water_mass + makeup_water_mass
             water_to_reinjection.set_liquid_flow_rate("H2O", water_to_reinjection_rate, tp=input.tp)
 

--- a/tests/files/test_boundary.xml
+++ b/tests/files/test_boundary.xml
@@ -35,7 +35,7 @@
 			<Component name="C4" phase="gas">1.4</Component>
 			<A name="temperature">90.0</A>
 			<A name="pressure">500.0</A>
-			<Contains>gas for transmission</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="TransmissionCompressor" dst="StorageCompressor" name="transmission compressor to storage compressor">
@@ -51,17 +51,17 @@
 		</Stream>
 
 		<Stream src="StorageCompressor" dst="StorageWell" name="storage compressor to storage well">
-			<Contains>gas for well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 
 		<Stream src="StorageWell" dst="StorageSeparator" name="storage well to storage separator">
-			<Contains>gas for separator</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 
 		<Stream src="StorageSeparator" dst="PostStorageCompressor" name="storage separator to post storage compressor">
-			<Contains>gas for storage</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="PostStorageCompressor" dst="GasDistribution" name="post storage compressor to gas distribution">
@@ -70,7 +70,7 @@
 
 
 		<Stream src="LNGLiquefaction" dst="LNGTransport" name="LNG liquefaction to LNG transportation">
-			<Contains>gas for transport</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="LNGTransport" dst="LNGRegasification" name="LNG transportation to LNG regasification">

--- a/tests/files/test_boundary_procs.xml
+++ b/tests/files/test_boundary_procs.xml
@@ -27,7 +27,7 @@
 		</Stream>
 
 		<Stream src="ProductionBoundary" dst="DistributionBoundary">
-			<Contains>gas for transmission</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>

--- a/tests/files/test_gui.xml
+++ b/tests/files/test_gui.xml
@@ -77,7 +77,7 @@
 		</Stream>
 
 		<Stream src="ProducedWaterTreatment" dst="After" name="produced water treatment to surface disposal">
-			<Contains>water for surface disposal</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 		<Stream src="ProducedWaterTreatment" dst="After" name="produced water treatment to subsurface disposal">
@@ -160,7 +160,7 @@
 		</Stream>
 
 		<Stream src="ProducedWaterTreatment" dst="After" name="produced water treatment to surface disposal">
-			<Contains>water for surface disposal</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 		<Stream src="ProducedWaterTreatment" dst="After" name="produced water treatment to subsurface disposal">

--- a/tests/files/test_model.xml
+++ b/tests/files/test_model.xml
@@ -59,14 +59,14 @@
 		<Process class="SteamGeneration"/>		<!-- needed by test_check_balance in test_thermofunction.py -->
 
 		<Stream src="ProcA" dst="ProcB">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream	src="ProcB" dst="ProductionBoundary">
 			<A name="temperature">90.0</A>
 			<A name="pressure">150.0</A>
 			<Component name="oil" phase="liquid">100</Component>
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 	</Field>
 
@@ -79,14 +79,14 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="ProcA" dst="ProcB">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream	src="ProcB" dst="ProductionBoundary">
 			<A name="temperature">90.0</A>
 			<A name="pressure">150.0</A>
 			<Component name="oil" phase="liquid">100</Component>
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 	</Field>
 
@@ -144,7 +144,7 @@
 		</Stream>
 
 		<Stream src="VRUCompressor" dst="ProductionBoundary">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 	</Field>
 
@@ -176,11 +176,11 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -213,11 +213,11 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -250,11 +250,11 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -285,11 +285,11 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -319,11 +319,11 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -355,12 +355,16 @@
 			<A name="pressure">500</A>
 		</Stream>
 
+		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
+			<Contains>gas</Contains>
+		</Stream>
+
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for gas lifting compressor">
 			<Contains>lifting gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -391,12 +395,16 @@
 			<A name="pressure">500</A>
 		</Stream>
 
+		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for reinjection compressor">
+			<Contains>gas</Contains>
+		</Stream>
+
 		<Stream src="GasPartition" dst="ProductionBoundary" name="gas for gas lifting compressor">
 			<Contains>lifting gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary" name="exported gas">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 	</Field>
 
@@ -544,7 +552,7 @@
 		</Stream>
 
 		<Stream src="Venting" dst="ProductionBoundary">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -681,7 +689,7 @@
 		</Stream>
 
 		<Stream src="PreMembraneChiller" dst="ProductionBoundary">
-			<Contains>gas for compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -696,7 +704,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="PreMembraneCompressor">
-			<Contains>gas for compressor</Contains>
+			<Contains>gas</Contains>
 			<Component name="N2" phase="gas">1238.9609</Component>
 			<Component name="CO2" phase="gas">8387.5011</Component>
 			<Component name="C1" phase="gas">22182.3128</Component>
@@ -708,7 +716,7 @@
 		</Stream>
 
 		<Stream src="PreMembraneCompressor" dst="ProductionBoundary">
-			<Contains>gas for CO2 membrane</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -722,7 +730,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="CO2Membrane">
-			<Contains>gas for CO2 membrane</Contains>
+			<Contains>gas</Contains>
 			<Component name="N2" phase="gas">1238.95945</Component>
 			<Component name="CO2" phase="gas">8387.49116</Component>
 			<Component name="C1" phase="gas">22182.28649</Component>
@@ -828,7 +836,7 @@
 		</Stream>
 
 		<Stream src="SourGasCompressor" dst="ProductionBoundary">
-			<Contains>gas for sour gas injection</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -842,7 +850,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="SourGasInjection">
-			<Contains>gas for sour gas injection</Contains>
+			<Contains>gas</Contains>
 			<Component name="N2" phase="gas">4.80935</Component>
 			<Component name="CO2" phase="gas">642.57354</Component>
 			<Component name="C1" phase="gas">85.98923</Component>
@@ -870,7 +878,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="GasReinjectionCompressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 			<Component name="N2" phase="gas">2538.13283</Component>
 			<Component name="CO2" phase="gas">23.02784</Component>
 			<Component name="C1" phase="gas">44497.80735</Component>
@@ -932,7 +940,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="Separation">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="N2" phase="gas">244.25402</Component>
 			<Component name="CO2" phase="gas">44.28207</Component>
 			<Component name="C1" phase="gas">4361.75720</Component>
@@ -982,7 +990,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="ReservoirWellInterface">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="N2" phase="gas">219.34013</Component>
 			<Component name="CO2" phase="gas">1861.01603</Component>
 			<Component name="C1" phase="gas">9421.01484</Component>
@@ -994,7 +1002,7 @@
 		</Stream>
 
 		<Stream src="ReservoirWellInterface" dst="ProductionBoundary">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 	</Field>
@@ -1008,7 +1016,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="ReservoirWellInterface">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="N2" phase="gas">4.89152</Component>
 			<Component name="CO2" phase="gas">2.79728</Component>
 			<Component name="C1" phase="gas">87.35015</Component>
@@ -1020,7 +1028,7 @@
 		</Stream>
 
 		<Stream src="ReservoirWellInterface" dst="ProductionBoundary">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 	</Field>
@@ -1041,7 +1049,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="DownholePump">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="N2" phase="gas">244.389711</Component>
 			<Component name="CO2" phase="gas">44.306667</Component>
 			<Component name="C1" phase="gas">4364.180279</Component>
@@ -1056,7 +1064,7 @@
 		</Stream>
 
 		<Stream src="DownholePump" dst="ProductionBoundary">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 	</Field>
@@ -1083,7 +1091,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="DownholePump" name="reservoir">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="N2" phase="gas">114.9419538</Component>
 			<Component name="CO2" phase="gas">20.8378531</Component>
 			<Component name="C1" phase="gas">2052.7627982</Component>
@@ -1108,7 +1116,7 @@
 		</Stream>
 
 		<Stream src="DownholePump" dst="ProductionBoundary">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 	</Field>
@@ -1126,7 +1134,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="CrudeOilDewatering">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 			<Component name="oil" phase="liquid">68951.16732</Component>
 			<Component name="H2O" phase="liquid">9653.16342</Component>
 			<A name="temperature">90.0</A>
@@ -1174,7 +1182,7 @@
 		</Stream>
 
 		<Stream src="CrudeOilStabilization" dst="ProductionBoundary" name="gas">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -1333,14 +1341,14 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="SteamGeneration" name="produced water">
-			<Contains>produced water for steam generation</Contains>
+			<Contains>produced water</Contains>
 			<Component name="H2O" phase="liquid">31929.035171733634</Component>
 			<A name="temperature">140.0</A>
 			<A name="pressure">200.0</A>
 		</Stream>
 
 		<Stream src="Before" dst="SteamGeneration" name="makeup water">
-			<Contains>makeup water for steam generation</Contains>
+			<Contains>makeup water</Contains>
 			<Component name="H2O" phase="liquid">0.0</Component>
 			<A name="temperature">60.0</A>
 			<A name="pressure">14.7</A>
@@ -1366,14 +1374,14 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="SteamGeneration" name="produced water">
-			<Contains>produced water for steam generation</Contains>
+			<Contains>produced water</Contains>
 			<Component name="H2O" phase="liquid">31929.035171733634</Component>
 			<A name="temperature">140.0</A>
 			<A name="pressure">200.0</A>
 		</Stream>
 
 		<Stream src="Before" dst="SteamGeneration" name="makeup water">
-			<Contains>makeup water for steam generation</Contains>
+			<Contains>makeup water</Contains>
 			<Component name="H2O" phase="liquid">0.0</Component>
 			<A name="temperature">60.0</A>
 			<A name="pressure">14.7</A>
@@ -1398,14 +1406,14 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="SteamGeneration" name="produced water">
-			<Contains>produced water for steam generation</Contains>
+			<Contains>produced water</Contains>
 			<Component name="H2O" phase="liquid">31929.035171733634</Component>
 			<A name="temperature">140.0</A>
 			<A name="pressure">200.0</A>
 		</Stream>
 
 		<Stream src="Before" dst="SteamGeneration" name="makeup water">
-			<Contains>makeup water for steam generation</Contains>
+			<Contains>makeup water</Contains>
 			<Component name="H2O" phase="liquid">0.0</Component>
 			<A name="temperature">60.0</A>
 			<A name="pressure">14.7</A>
@@ -1446,12 +1454,12 @@
 			<A name="pressure">100.0</A>
 		</Stream>
 
-		<Stream src="WaterTreatment" dst="ProductionBoundary" name="makeup water for steam generation">
-			<Contains>makeup water for steam generation</Contains>
+		<Stream src="WaterTreatment" dst="ProductionBoundary" name="makeup water">
+			<Contains>makeup water</Contains>
 		</Stream>
 
-		<Stream src="WaterTreatment" dst="ProductionBoundary" name="produced water for steam generation">
-			<Contains>produced water for steam generation</Contains>
+		<Stream src="WaterTreatment" dst="ProductionBoundary" name="produced water">
+			<Contains>produced water</Contains>
 		</Stream>
 
 	</Field>

--- a/tests/files/test_model.xml
+++ b/tests/files/test_model.xml
@@ -781,7 +781,7 @@
 		</Stream>
 
 		<Stream src="CO2ReinjectionCompressor" dst="ProductionBoundary">
-			<Contains>gas for CO2 injection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -795,7 +795,7 @@
 		<Process class="Boundary" boundary="Production"/>
 
 		<Stream src="Before" dst="CO2InjectionWell">
-			<Contains>gas for CO2 injection well</Contains>
+			<Contains>gas</Contains>
 			<Component name="N2" phase="gas">530.281476</Component>
 			<Component name="CO2" phase="gas">7577.609834</Component>
 			<Component name="C1" phase="gas">372.658027</Component>
@@ -890,7 +890,7 @@
 		</Stream>
 
 		<Stream src="GasReinjectionCompressor" dst="ProductionBoundary">
-			<Contains>gas for gas reinjection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 	</Field>
@@ -1355,7 +1355,7 @@
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="ProductionBoundary" name="water">
-			<Contains>recycled water</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 	</Field>
@@ -1388,7 +1388,7 @@
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="ProductionBoundary" name="water">
-			<Contains>recycled water</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 	</Field>
@@ -1420,7 +1420,7 @@
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="ProductionBoundary" name="water">
-			<Contains>recycled water</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 	</Field>

--- a/tests/files/test_process_groups.xml
+++ b/tests/files/test_process_groups.xml
@@ -543,7 +543,7 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="TransmissionCompressor">
-			<Contains>gas for transmission</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary">
@@ -575,15 +575,15 @@
         </Stream>
 
         <Stream src="StorageCompressor" dst="StorageWell">
-            <Contains>gas for well</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="StorageWell" dst="StorageSeparator">
-            <Contains>gas for separator</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="StorageSeparator" dst="PostStorageCompressor">
-            <Contains>gas for storage</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="PostStorageCompressor" dst="GasDistribution">
@@ -591,7 +591,7 @@
         </Stream>
 
         <Stream src="LNGLiquefaction" dst="LNGTransport">
-            <Contains>gas for transport</Contains>
+            <Contains>gas</Contains>
         </Stream>
 
         <Stream src="LNGTransport" dst="LNGRegasification">

--- a/tests/files/test_process_groups.xml
+++ b/tests/files/test_process_groups.xml
@@ -280,7 +280,7 @@
 		</Stream>
 
 		<Stream src="Separation" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 <!--		oil processing path-->
@@ -313,7 +313,7 @@
 		</Stream>
 
 		<Stream src="CrudeOilStabilization" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="HeavyOilDilution" dst="CrudeOilStorage">
@@ -372,24 +372,24 @@
 
 <!--		water processing path-->
 		<Stream src="WaterTreatment" dst="ProductionBoundary">
-			<Contains>water for surface disposal</Contains>
+			<Contains>water</Contains>
 			<Contains>water for subsurface disposal</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="SteamGeneration">
-			<Contains>produced water for steam generation</Contains>
+			<Contains>produced water</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="SteamGeneration" name="makeup water treatment">
-			<Contains>makeup water for steam generation</Contains>
+			<Contains>makeup water</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="WaterInjection" name="produced water treatment">
-			<Contains>produced water for water injection</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 		<Stream src="WaterTreatment" dst="WaterInjection">
-			<Contains>makeup water for water injection</Contains>
+			<Contains>water</Contains>
 		</Stream>
 
 		<Stream src="SteamGeneration" dst="WaterTreatment">
@@ -408,15 +408,15 @@
 		</Stream>
 
 		<Stream src="Flaring" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="Venting" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="VRUCompressor" dst="GasGathering">
-			<Contains>gas for gas gathering</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasGathering" dst="GasDehydration">
@@ -440,11 +440,11 @@
 		</Stream>
 
 		<Stream src="PreMembraneChiller" dst="PreMembraneCompressor">
-			<Contains>gas for compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="PreMembraneCompressor" dst="CO2Membrane">
-			<Contains>gas for CO2 membrane</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="CO2Membrane" dst="AcidGasRemoval">
@@ -496,7 +496,7 @@
 		</Stream>
 
 		<Stream src="SourGasCompressor" dst="SourGasInjection">
-			<Contains>gas for sour gas injection</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="SourGasInjection" dst="Reservoir" impute="false">
@@ -528,7 +528,7 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="GasReinjectionCompressor">
-			<Contains>gas for gas reinjection compressor</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasReinjectionCompressor" dst="GasReinjectionWell">
@@ -544,7 +544,7 @@
 		</Stream>
 
 		<Stream src="GasPartition" dst="ProductionBoundary">
-			<Contains>gas</Contains>
+			<Contains>exported gas</Contains>
 		</Stream>
 
 		<Stream src="TransmissionCompressor" dst="TransportationBoundary" name="transmission gas for storage">

--- a/tests/files/test_process_groups.xml
+++ b/tests/files/test_process_groups.xml
@@ -484,11 +484,11 @@
 		</Stream>
 
 		<Stream src="CO2ReinjectionCompressor" dst="CO2InjectionWell">
-			<Contains>gas for CO2 injection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="CO2InjectionWell" dst="Reservoir" impute="false">
-			<Contains>gas for reservoir</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasDehydration" dst="SourGasCompressor">
@@ -499,9 +499,12 @@
 			<Contains>gas</Contains>
 		</Stream>
 
+		<!-- doesn't match code for SourGasInjection -->
+		<!--
 		<Stream src="SourGasInjection" dst="Reservoir" impute="false">
 			<Contains>gas for reservoir</Contains>
 		</Stream>
+		-->
 
 		<Stream src="Demethanizer" dst="GasPartition">
 			<Contains>gas for gas partition</Contains>
@@ -532,11 +535,11 @@
 		</Stream>
 
 		<Stream src="GasReinjectionCompressor" dst="GasReinjectionWell">
-			<Contains>gas for gas reinjection well</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasReinjectionWell" dst="Reservoir" impute="false">
-			<Contains>gas for reservoir</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="GasPartition" dst="TransmissionCompressor">

--- a/tests/files/test_process_loop_model.xml
+++ b/tests/files/test_process_loop_model.xml
@@ -21,12 +21,12 @@
 			<Component name="oil" phase="liquid">100</Component>
 			<Component name="H2O" phase="liquid">80</Component>
 			<Component name="C1" phase="gas">200</Component>
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<!-- Creates a process loop -->
 		<Stream src="LoopProc2" dst="LoopProc3">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream src="LoopProc3" dst="LoopProc2">
@@ -54,12 +54,12 @@
 			<Component name="oil" phase="liquid">100</Component>
 			<Component name="H2O" phase="liquid">80</Component>
 			<Component name="C1" phase="gas">200</Component>
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<!-- Creates a process loop -->
 		<Stream src="LoopProc2" dst="LoopProc3">
-			<Contains>crude oil</Contains>
+			<Contains>oil</Contains>
 		</Stream>
 
 		<Stream src="LoopProc3" dst="LoopProc2">

--- a/tests/test_intermediate_boundary.py
+++ b/tests/test_intermediate_boundary.py
@@ -21,7 +21,7 @@ xml_string = """
     
     <Stream src="Boundary_proc_1" dst="Boundary_proc_2">
       <Component name="oil" phase="liquid">100</Component>
-      <Contains>crude oil</Contains>
+      <Contains>oil</Contains>
     </Stream>
     
     <Stream src="Boundary_proc_1" dst="Boundary_proc_3">
@@ -30,7 +30,7 @@ xml_string = """
     </Stream>
 
     <Stream src="Boundary_proc_2" dst="ProductionBoundary">
-      <Contains>crude oil</Contains>
+      <Contains>oil</Contains>
     </Stream>
         
     <Stream src="Boundary_proc_3" dst="ProductionBoundary">
@@ -38,14 +38,14 @@ xml_string = """
     </Stream>
     
     <Stream src="ProductionBoundary" dst="Boundary_proc_4" name="oil stream 1">
-      <Contains>crude oil</Contains>
+      <Contains>oil</Contains>
     </Stream>
     <Stream src="ProductionBoundary" dst="Boundary_proc_4" name="gas stream 1">
       <Contains>natural gas</Contains>
     </Stream>
     
     <Stream src="Boundary_proc_4" dst="TransportationBoundary" name="oil stream 2">
-      <Contains>crude oil</Contains>
+      <Contains>oil</Contains>
     </Stream>
     <Stream src="Boundary_proc_4" dst="TransportationBoundary" name="gas stream 2">
       <Contains>natural gas</Contains>
@@ -63,10 +63,10 @@ class Boundary_proc_1(Process):
 
 class Boundary_proc_2(Process):
     def run(self, analysis):
-        in_stream = self.find_input_stream("crude oil")
+        in_stream = self.find_input_stream("oil")
         if in_stream.is_uninitialized():
             return
-        out_stream = self.find_output_stream("crude oil")
+        out_stream = self.find_output_stream("oil")
         out_stream.copy_flow_rates_from(in_stream)
 
 
@@ -81,7 +81,7 @@ class Boundary_proc_3(Process):
 
 class Boundary_proc_4(Process):
     def run(self, analysis):
-        for content in ("crude oil", "natural gas"):
+        for content in ("oil", "natural gas"):
             in_stream = self.find_input_stream(content)
             if in_stream.is_uninitialized():
                 return

--- a/tests/test_process_loop.py
+++ b/tests/test_process_loop.py
@@ -9,19 +9,19 @@ class LoopProc1(Process):
         # find appropriate streams by checking connected processes' capabilities
         oil_flow_rate = ureg.Quantity(100.0, Stream.units())
 
-        out_stream = self.find_output_stream('crude oil')
+        out_stream = self.find_output_stream('oil')
         out_stream.set_liquid_flow_rate('oil', oil_flow_rate)
 
 
 class LoopProc2(Process):
     def run(self, analysis):
-        crude_oil = self.find_input_stream('crude oil')
+        crude_oil = self.find_input_stream('oil')
         recycled_water = self.find_input_stream("water")
 
         if crude_oil.is_uninitialized() and recycled_water.is_uninitialized():
             return
 
-        output = self.find_output_stream("crude oil")
+        output = self.find_output_stream("oil")
         output.copy_flow_rates_from(crude_oil)
         output.set_liquid_flow_rate("H2O", recycled_water.liquid_flow_rate("H2O"))
         self.set_iteration_value(output.total_flow_rate())
@@ -29,7 +29,7 @@ class LoopProc2(Process):
 
 class LoopProc3(Process):
     def run(self, analysis):
-        input = self.find_input_stream("crude oil")
+        input = self.find_input_stream("oil")
         if input.is_uninitialized():
             return
         water = input.liquid_flow_rate("H2O")

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -77,21 +77,21 @@ def procB(test_model):
 
 
 def test_find_input_streams_dict(procB):
-    obj = procB.find_input_streams("crude oil")
+    obj = procB.find_input_streams("oil")
     assert isinstance(obj, dict) and len(obj) == 1
 
 
 def test_find_input_streams_list(procB):
-    obj = procB.find_input_streams("crude oil", as_list=True)
+    obj = procB.find_input_streams("oil", as_list=True)
     assert isinstance(obj, list) and len(obj) == 1
 
 
 def test_find_input_stream(procB):
-    procB.find_input_stream("crude oil")
+    procB.find_input_stream("oil")
 
 
 def test_find_output_stream(process):
-    process.find_output_stream("crude oil")
+    process.find_output_stream("oil")
 
 
 def test_find_input_stream_error(procB):
@@ -358,11 +358,11 @@ def test_N2Flooding(test_model):
     field.run(analysis)
     proc = field.find_process('GasPartition')
     # ensure total energy flow rates
-    total = proc.find_output_stream("gas for gas reinjection compressor").gas_flow_rates().sum()
+    total = proc.find_output_stream("gas").gas_flow_rates().sum()
     expected = ureg.Quantity(25086.65151856, "tonne/day")
     assert approx_equal(total, expected, rel=10e-4)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(758.78647, "tonne/day")
     assert approx_equal(total, expected)
 
@@ -373,11 +373,11 @@ def test_CO2Flooding_CO2_reinjection(test_model_with_change):
     field.run(analysis)
     proc = field.find_process('GasPartition')
     # ensure total energy flow rates
-    total = proc.find_output_stream("gas for gas reinjection compressor").gas_flow_rates().sum()
+    total = proc.find_output_stream("gas").gas_flow_rates().sum()
     expected = ureg.Quantity(9976.19977172, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(24885.555110000005, "tonne/day")
     assert approx_equal(total, expected)
 
@@ -388,11 +388,11 @@ def test_CO2Flooding_non_zero(test_model_with_change):
     field.run(analysis)
     proc = field.find_process('GasPartition')
     # ensure total energy flow rates
-    total = proc.find_output_stream("gas for gas reinjection compressor").gas_flow_rates().sum()
+    total = proc.find_output_stream("gas").gas_flow_rates().sum()
     expected = ureg.Quantity(9976.199771722018, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(24885.555110000005, "tonne/day")
     assert approx_equal(total, expected)
 
@@ -403,11 +403,11 @@ def test_NGFlooding_onsite(test_model):
     field.run(analysis)
     proc = field.find_process('GasPartition')
     # ensure total energy flow rates
-    total = proc.find_output_stream("gas for gas reinjection compressor").gas_flow_rates().sum()
+    total = proc.find_output_stream("gas").gas_flow_rates().sum()
     expected = ureg.Quantity(3825.799, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(22185.893, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
@@ -419,12 +419,12 @@ def test_CO2Flooding_sour_gas_reinjection(test_model_with_change):
     proc = field.find_process('GasPartition')
 
     # ensure total energy flow rates
-    s = proc.find_output_stream("gas for gas reinjection compressor")
+    s = proc.find_output_stream("gas")
     total = s.gas_flow_rates().sum()
     expected = ureg.Quantity(9976.19977, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(24885.5551, "tonne/day")
     assert approx_equal(total, expected, rel=10e-4)
 
@@ -435,11 +435,11 @@ def test_NGFlooding_offset(test_model):
     field.run(analysis)
     proc = field.find_process('GasPartition')
     # ensure total energy flow rates
-    total = proc.find_output_stream("gas for gas reinjection compressor").gas_flow_rates().sum()
+    total = proc.find_output_stream("gas").gas_flow_rates().sum()
     expected = ureg.Quantity(428933.382, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = 0.0
     assert total == expected
 
@@ -454,7 +454,7 @@ def test_GasLifting_low_GLIR(test_model):
     expected = ureg.Quantity(176.061318, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = ureg.Quantity(1486.42622, "tonne/day")
     assert approx_equal(total, expected, rel=10e-3)
 
@@ -469,7 +469,7 @@ def test_GasLifting_high_GLIR(test_model):
     expected = ureg.Quantity(1662.48754, "tonne/day")
     assert approx_equal(total, expected)
 
-    total = proc.find_output_stream("gas").gas_flow_rates().sum()
+    total = proc.find_output_stream("exported gas").gas_flow_rates().sum()
     expected = 0.0
     assert total == expected
 
@@ -481,7 +481,7 @@ def test_ReservoirWellInterface(test_model):
     field.run(analysis)
     proc = field.find_process('ReservoirWellInterface')
     # ensure output stream pressure
-    pressure = proc.find_output_stream("crude oil").tp.P
+    pressure = proc.find_output_stream("oil").tp.P
     expected = ureg.Quantity(1324.23673, "mmbtu/day")
     assert approx_equal(pressure, expected, rel=10e-3)
 
@@ -493,7 +493,7 @@ def test_ReservoirWellInterface_CO2_flood(test_model):
     field.run(analysis)
     proc = field.find_process('ReservoirWellInterface')
     # ensure output stream pressure
-    pressure = proc.find_output_stream("crude oil").tp.P
+    pressure = proc.find_output_stream("oil").tp.P
     expected = ureg.Quantity(1520.21852, "mmbtu/day")
     assert approx_equal(pressure, expected, rel=10e-4)
 


### PR DESCRIPTION
This is a big PR, affecting numerous process modules, XML files, and test files. The point was to simplify stream content names when there was no need to include destination process names in the contents. For example, when a process has a single output and feeds a process with a single input. Rather than calling this "gas for {destination}", it can be simply "gas".

The goal is to reduce content names to a small set that can be made explicit for validation purposes.

I'm also contemplating a small code change that would facilitate other stream content simplifications: add a `regex=False` argument to `find_input_streams` and `find_output_streams` to allow a process to do, e.g., `find_input_streams(r"gas.*", regex=True)`, which would allow some sources to label their stream contents simply "gas" while others that partition gas between multiple processes might use "gas for XXX" type names.

Currently, if one process partitions its outputs and thus names them distinctly as "gas for XXX" and "gas for YYY" it forces other inputs to the same destination process to adopt those names. By using regexs we can eliminate this content name "contagion".