### PR TITLE
Short script to print a summary of stream contents in opgee.xml

### DIFF
--- a/opgee/bin/stream_contents.py
+++ b/opgee/bin/stream_contents.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#
+# Read opgee.xml and write out a sorted list of unique stream content names
+#
+from lxml import etree as ET
+
+from opgee.config import getParam
+from opgee.pkg_utils import resourceStream
+from opgee.XMLFile import XMLFile
+
+def main():
+    opgee_xml = getParam('OPGEE.ModelFile')
+    base_stream = resourceStream(opgee_xml, stream_type='bytes', decode=None)
+    xml_file = XMLFile(base_stream, schemaPath='etc/opgee.xsd')
+    root = xml_file.getRoot()
+
+    # use a Set to store unique values
+    contents = {elt.text for elt in root.findall(".//Stream/Contains")}
+    for txt in sorted(contents):
+        print(txt)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Prints sorted list of all stream contents specified in opgee.xml. The idea is to help shorten this list to a smaller set of pre-defined content names.

Current output for master branch:
```
CO2
LNG
LPG
None
crude oil
gas
gas for AGR
gas for CO2 compressor
gas for CO2 injection well
gas for CO2 membrane
gas for NGL
gas for Ryan Holmes
gas for VRU
gas for chiller
gas for compressor
gas for demethanizer
gas for distribution
gas for flaring
gas for gas dehydration
gas for gas gathering
gas for gas partition
gas for gas reinjection compressor
gas for gas reinjection well
gas for partition
gas for reservoir
gas for separator
gas for sour gas compressor
gas for sour gas injection
gas for storage
gas for transmission
gas for transport
gas for venting
gas for well
lifting gas
makeup water for steam generation
methane slip
oil
oil for dilution
oil for stabilization
oil for storage
oil for upgrading
petrocoke
process gas
produced water for steam generation
recycled water
water
water for subsurface disposal
water for surface disposal
water for water injection
```

Current output for the `rename-stream-contents` branch:
```
CO2
LNG
LPG
None
exported gas
gas
gas for AGR
gas for CO2 compressor
gas for NGL
gas for Ryan Holmes
gas for VRU
gas for chiller
gas for demethanizer
gas for distribution
gas for flaring
gas for gas dehydration
gas for gas partition
gas for partition
gas for sour gas compressor
gas for storage
gas for venting
lifting gas
makeup water
methane slip
oil
oil for dilution
oil for stabilization
oil for storage
oil for upgrading
petrocoke
process gas
produced water
water
water for subsurface disposal
```