### PR TITLE
Moved "iteration_tolerance" from a Model attribute to a class variable

### DIFF
--- a/opgee/etc/attributes.xml
+++ b/opgee/etc/attributes.xml
@@ -14,7 +14,6 @@
 
       <!-- Maximum number of iterations for process loops -->
       <AttrDef name="maximum_iterations" type="int">100</AttrDef>
-      <AttrDef name="iteration_tolerance" type="float">0.000001</AttrDef>
 
       <!-- Change threshold for iteration loops. Requires a Process to set a change variable. -->
       <AttrDef name="maximum_change" type="float">0.001</AttrDef>

--- a/opgee/processes/gas_partition.py
+++ b/opgee/processes/gas_partition.py
@@ -26,6 +26,7 @@ class GasPartition(Process):
     """
     Gas partition is to check the reasonable amount of gas goes to gas lifting and gas reinjection
     """
+    iteration_tolerance = 0.000001
 
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
@@ -67,7 +68,6 @@ class GasPartition(Process):
         self.impurity_N2_in_CO2 = None
         self.is_first_loop = None
         self.is_gas_flooding_visited = None
-        self.iteration_tolerance = None
         self.natural_gas_reinjection = None
         self.oil_volume_rate = None
         self.reset_flag = None
@@ -89,7 +89,6 @@ class GasPartition(Process):
         self.GLIR = field.GLIR
         self.oil_volume_rate = field.oil_volume_rate
         self.WOR = field.WOR
-        self.iteration_tolerance = self.model.attr("iteration_tolerance")
 
         self.flood_gas_type = field.flood_gas_type
         self.N2_flooding_tp = TemperaturePressure(


### PR DESCRIPTION
Moved "iteration_tolerance" from a Model attribute to a class variable in GasPartition class since it was used only there.