### PR TITLE
Transmission compressor

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -33,4 +33,5 @@ Supporting Modules
 
    opgee.config
    opgee.subcommand
+   opgee.units
    opgee.utils

--- a/opgee/__init__.py
+++ b/opgee/__init__.py
@@ -1,21 +1,5 @@
-import pint
 import warnings
-
-from .pkg_utils import resourceStream
 
 # warnings.filterwarnings("ignore", category=DeprecationWarning)
 # warnings.filterwarnings("error", category=UserWarning) # turn warning into error to debug
 warnings.filterwarnings("ignore", category=UserWarning) # turn warning into error to debug
-
-ureg = None
-
-if not ureg:
-    ureg = pint.get_application_registry()
-
-    # Standard def is 31.5 gal, not 42 gal as in petrochemical world.
-    # We redefine this in etc/units.txt and delete the old def first.
-    del ureg._units['bbl']
-
-    stream = resourceStream('etc/units.txt')
-    lines = [line.strip() for line in stream.readlines()]
-    ureg.load_definitions(lines)

--- a/opgee/attributes.py
+++ b/opgee/attributes.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 import pandas as pd
 
-from . import ureg
+from .units import ureg
 from .core import (OpgeeObject, XmlInstantiable, A, instantiate_subelts,
                    elt_name, validate_unit, magnitude)
 from .error import AttributeError, ModelValidationError

--- a/opgee/attributes.py
+++ b/opgee/attributes.py
@@ -10,9 +10,8 @@ from collections import defaultdict
 
 import pandas as pd
 
-from .units import ureg
-from .core import (OpgeeObject, XmlInstantiable, A, instantiate_subelts,
-                   elt_name, validate_unit, magnitude)
+from .units import ureg, validate_unit, magnitude
+from .core import OpgeeObject, XmlInstantiable, A, instantiate_subelts, elt_name
 from .error import AttributeError, ModelValidationError
 from .log import getLogger
 from .utils import coercible

--- a/opgee/combine_streams.py
+++ b/opgee/combine_streams.py
@@ -8,7 +8,7 @@
 #
 import pandas as pd
 
-from . import ureg
+from .units import ureg
 from .core import STP
 from .core import TemperaturePressure
 from .log import getLogger

--- a/opgee/container.py
+++ b/opgee/container.py
@@ -7,12 +7,13 @@
 # See LICENSE.txt for license details.
 #
 from .attributes import AttrDefs, AttributeMixin
-from .core import  ureg, XmlInstantiable
+from .core import XmlInstantiable
 from .emissions import Emissions
 from .energy import Energy
 from .error import OpgeeException
 from .import_export import ImportExport
 from .log import getLogger
+from .units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/core.py
+++ b/opgee/core.py
@@ -10,35 +10,9 @@ import pint
 import time
 import datetime
 
-from .units import ureg
+from .units import ureg, validate_unit
 from .error import OpgeeException, AbstractMethodError, ModelValidationError
-from .log import getLogger
 from .utils import coercible, getBooleanXML
-
-_logger = getLogger(__name__)
-
-def magnitude(value, units=None):
-    """
-    Return the magnitude of ``value``. If ``value`` is a ``pint.Quantity`` and
-    ``units`` is not None, check that ``value`` has the expected units and
-    return the magnitude of ``value``. If ``value`` is not a ``pint.Quantity``,
-    just return it.
-
-    :param value: (float or pint.Quantity) the value for which we return the magnitude.
-    :param units: (None or pint.Unit) the expected units
-    :return: the magnitude of `value`
-    """
-    if isinstance(value, ureg.Quantity):
-        # if optional units are provided, validate them
-        if units:
-            if not isinstance(units, pint.Unit):
-                units = ureg.Unit(units)
-            if value.units != units:
-                raise OpgeeException(f"magnitude: value {value} units are not {units}")
-
-        return value.m
-    else:
-        return value
 
 
 def name_of(obj):
@@ -219,32 +193,6 @@ class XmlInstantiable(OpgeeObject):
             return None
 
         return self.parent.find_container(cls)  # recursively ascend the graph
-
-
-# to avoid redundantly reporting bad units
-_undefined_units = {}
-
-
-def validate_unit(unit):
-    """
-    Return the ``pint.Unit`` associated with the string ``unit``, or ``None``
-    if ``unit`` is ``None`` or not in the unit registry.
-
-    :param unit: (str) a string representation of a ``pint.Unit``
-
-    :return: (pint.Unit or None)
-    """
-    if not unit:
-        return None
-
-    if unit in ureg:
-        return ureg.Unit(unit)
-
-    if unit not in _undefined_units:
-        _logger.warning(f"Unit '{unit}' is not in the UnitRegistry")
-        _undefined_units[unit] = 1
-
-    return None
 
 
 class A(OpgeeObject):

--- a/opgee/core.py
+++ b/opgee/core.py
@@ -10,7 +10,7 @@ import pint
 import time
 import datetime
 
-from . import ureg
+from .units import ureg
 from .error import OpgeeException, AbstractMethodError, ModelValidationError
 from .log import getLogger
 from .utils import coercible, getBooleanXML

--- a/opgee/emissions.py
+++ b/opgee/emissions.py
@@ -9,13 +9,10 @@
 import pandas as pd
 import pint
 
-from .units import ureg
-from .core import OpgeeObject, magnitude
+from .units import magnitude, ureg
+from .core import OpgeeObject
 from .error import OpgeeException
-from .log import getLogger
 from .stream import Stream
-
-_logger = getLogger(__name__)
 
 EM_COMBUSTION = 'Combustion'
 EM_LAND_USE = 'Land-use'

--- a/opgee/emissions.py
+++ b/opgee/emissions.py
@@ -9,7 +9,7 @@
 import pandas as pd
 import pint
 
-from . import ureg
+from .units import ureg
 from .core import OpgeeObject, magnitude
 from .error import OpgeeException
 from .log import getLogger

--- a/opgee/energy.py
+++ b/opgee/energy.py
@@ -8,7 +8,7 @@
 #
 import pandas as pd
 
-from . import ureg
+from .units import ureg
 from .core import OpgeeObject
 from .error import OpgeeException
 from .log import getLogger

--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -393,7 +393,7 @@
 		</Stream>
 
 		<Stream src="HeavyOilUpgrading" dst="ProductionBoundary">
-			<Contains>process gas</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="CrudeOilStorage" dst="CrudeOilTransport">

--- a/opgee/field.py
+++ b/opgee/field.py
@@ -10,7 +10,7 @@ import networkx as nx
 import pint
 import pandas as pd
 
-from . import ureg
+from .units import ureg
 from .config import getParamAsList
 from .constants import DETAILED_RESULT
 from .container import Container

--- a/opgee/gui/results_pane.py
+++ b/opgee/gui/results_pane.py
@@ -1,9 +1,9 @@
 from dash import dcc, html
 from dash.dependencies import Input, Output, State
+
 from ..error import ZeroEnergyFlowError
 from ..log import getLogger
-
-from .widgets import get_analysis_and_field, OpgeePane, horiz_space
+from .widgets import OpgeePane, get_analysis_and_field, horiz_space
 
 _logger = getLogger(__name__)
 
@@ -72,7 +72,7 @@ class ResultsPane(OpgeePane):
                 ci = field.compute_carbon_intensity(analysis)
             except ZeroEnergyFlowError:
                 return dcc.Markdown("**Cannot compute CI: zero energy flow at system boundary**")
-                # from .. import ureg
+                # from ..units import ureg
                 # _logger.warning(f"ci_text: {e}")
                 # ci = ureg.Quantity(0, "grams/MJ")
 

--- a/opgee/gui/results_pane.py
+++ b/opgee/gui/results_pane.py
@@ -72,9 +72,6 @@ class ResultsPane(OpgeePane):
                 ci = field.compute_carbon_intensity(analysis)
             except ZeroEnergyFlowError:
                 return dcc.Markdown("**Cannot compute CI: zero energy flow at system boundary**")
-                # from ..units import ureg
-                # _logger.warning(f"ci_text: {e}")
-                # ci = ureg.Quantity(0, "grams/MJ")
 
             return f"CI: {ci.m:0.2f} g CO2e/MJ LHV of {analysis.fn_unit}"
 

--- a/opgee/gui/settings_pane.py
+++ b/opgee/gui/settings_pane.py
@@ -112,7 +112,7 @@ class SettingsPane(OpgeePane):
         :return: none
         """
         from lxml import etree as ET
-        from ..core import magnitude
+        from ..units import magnitude
         from ..utils import coercible
 
         attr_defs = AttrDefs.get_instance()

--- a/opgee/gui/widgets.py
+++ b/opgee/gui/widgets.py
@@ -1,7 +1,8 @@
 from dash import dcc, html
-from ..core import magnitude
+
 from ..error import OpgeeException
 from ..log import getLogger
+from ..units import magnitude
 
 _logger = getLogger(__name__)
 

--- a/opgee/import_export.py
+++ b/opgee/import_export.py
@@ -159,7 +159,7 @@ class ImportExport(OpgeeObject):
         """
 
         def _sum(series, name):
-            from . import ureg
+            from .units import ureg
             # Sum of an empty series is returned as int(0); need to initialize units
             return series.sum() if len(series) > 0 else ureg.Quantity(0.0, self.unit_dict[name])
 

--- a/opgee/model.py
+++ b/opgee/model.py
@@ -8,7 +8,7 @@
 #
 import pint
 
-from . import ureg
+from .units import ureg
 from .analysis import Analysis
 from .container import Container
 from .core import elt_name, instantiate_subelts

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -10,14 +10,13 @@ from typing import Union, Optional
 
 import pandas as pd
 import pint
-import re
 
-from .units import ureg
+from .units import ureg, magnitude
 from .attributes import AttrDefs, AttributeMixin
 from .combine_streams import combine_streams
 from .config import getParamAsBoolean
 from .container import Container
-from .core import OpgeeObject, XmlInstantiable, elt_name, instantiate_subelts, magnitude
+from .core import OpgeeObject, XmlInstantiable, elt_name, instantiate_subelts
 from .emissions import Emissions, EM_COMBUSTION
 from .energy import EN_ELECTRICITY, Energy
 from .error import OpgeeException, AbstractMethodError, OpgeeIterationConverged, ModelValidationError
@@ -1076,7 +1075,7 @@ class Aggregator(Container):
     def __init__(self, name, attr_dict=None, parent=None):
         super().__init__(name, attr_dict=attr_dict, parent=parent)
 
-    def add_children(self, aggs=None, procs=None, **kwargs):
+    def add_children(self, aggs=None, procs=None):
         super().add_children(aggs=aggs, procs=procs)
 
     @classmethod

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pint
 import re
 
-from . import ureg
+from .units import ureg
 from .attributes import AttrDefs, AttributeMixin
 from .combine_streams import combine_streams
 from .config import getParamAsBoolean

--- a/opgee/processes/CO2_reinjection_compressor.py
+++ b/opgee/processes/CO2_reinjection_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
+from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/CO2_reinjection_compressor.py
+++ b/opgee/processes/CO2_reinjection_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
-from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/acid_gas_removal.py
+++ b/opgee/processes/acid_gas_removal.py
@@ -6,18 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process, run_corr_eqns
-from ..units import ureg
 from .compressor import Compressor
-from .shared import (
-    get_bounded_value,
-    get_energy_carrier,
-    get_energy_consumption,
-    predict_blower_energy_use,
-)
+from .shared import get_energy_carrier, predict_blower_energy_use, get_bounded_value, get_energy_consumption
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/acid_gas_removal.py
+++ b/opgee/processes/acid_gas_removal.py
@@ -6,13 +6,18 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process, run_corr_eqns
+from ..units import ureg
 from .compressor import Compressor
-from .shared import get_energy_carrier, predict_blower_energy_use, get_bounded_value, get_energy_consumption
+from .shared import (
+    get_bounded_value,
+    get_energy_carrier,
+    get_energy_consumption,
+    predict_blower_energy_use,
+)
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/bitumen_mining.py
+++ b/opgee/processes/bitumen_mining.py
@@ -6,14 +6,14 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_DIESEL, EN_ELECTRICITY, EN_NATURAL_GAS
-from ..error import OpgeeException
+from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_DIESEL
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
-from ..units import ureg
+from ..error import OpgeeException
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/bitumen_mining.py
+++ b/opgee/processes/bitumen_mining.py
@@ -6,14 +6,14 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_DIESEL
+from ..energy import EN_DIESEL, EN_ELECTRICITY, EN_NATURAL_GAS
+from ..error import OpgeeException
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
-from ..error import OpgeeException
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/compressor.py
+++ b/opgee/processes/compressor.py
@@ -6,20 +6,36 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
-from ..core import OpgeeObject
-from .shared import get_energy_consumption
+from typing import Optional, Sequence, Tuple
+
+from pint.facets.plain import PlainQuantity as Quantity
+
+from opgee.core import OpgeeObject, TemperaturePressure
+from opgee.processes.shared import get_energy_consumption
+from opgee.stream import Stream
+from opgee.units import ureg
+
+# type aliases
+Q_Float = Quantity[float]
+Q_IntTuple = Tuple[Q_Float, int]
+
+
 
 _power = [1, 1 / 2, 1 / 3, 1 / 4, 1 / 5]
 
-
 class Compressor(OpgeeObject):
-
     def __init__(self, field):
         self.field = field
 
     @staticmethod
-    def get_compressor_work_temp(field, inlet_temp, inlet_press, gas_stream, compression_ratio, num_of_compression):
+    def get_compressor_work_temp(
+        field,
+        inlet_temp,
+        inlet_press,
+        gas_stream,
+        compression_ratio,
+        num_of_compression,
+    ) -> Tuple[Q_Float, Q_Float, Q_Float]:
         """
 
         :param field:
@@ -34,18 +50,28 @@ class Compressor(OpgeeObject):
         corrected_temp = gas.corrected_pseudocritical_temperature(gas_stream)
         corrected_press = gas.corrected_pseudocritical_pressure(gas_stream)
         ratio_of_specific_heat = gas.ratio_of_specific_heat(gas_stream)
-        work_temp1 = 3.027 * 14.7 / (60 + 460) * ratio_of_specific_heat / (ratio_of_specific_heat - 1)
+        work_temp1: Quantity = (
+            3.027
+            * 14.7
+            / (60 + 460)
+            * ratio_of_specific_heat
+            / (ratio_of_specific_heat - 1)
+        )
         ratio = (ratio_of_specific_heat - 1) / ratio_of_specific_heat
-        work = 0
-        for j in range(num_of_compression):
+        work: Quantity = ureg.Quantity(0.0, "frac * rankine")
+
+        for _ in range(num_of_compression):
             inlet_reduced_temp = inlet_temp.to("rankine") / corrected_temp
             inlet_reduced_press = inlet_press / corrected_press
             z_factor = gas.Z_factor(inlet_reduced_temp, inlet_reduced_press)
 
-            work_temp2 = (compression_ratio ** z_factor) ** ratio - 1
+            work_temp2 = (compression_ratio**z_factor) ** ratio - 1
             work += work_temp1 * work_temp2 * inlet_temp.to("rankine")
 
-            delta_temp = (inlet_temp.to("rankine") * compression_ratio ** (z_factor * ratio) - inlet_temp) * 0.2
+            delta_temp = (
+                inlet_temp.to("rankine") * compression_ratio ** (z_factor * ratio)
+                - inlet_temp
+            ) * 0.2
             inlet_temp = ureg.Quantity(inlet_temp.m + delta_temp.m, "degF")
             inlet_press = compression_ratio * inlet_press
 
@@ -53,59 +79,32 @@ class Compressor(OpgeeObject):
         return work_sum, inlet_temp, inlet_press
 
     @staticmethod
-    def get_compression_ratio_stages(overall_compression_ratio_stages):
+    def get_compression_ratio_stages(
+        overall_compression_ratio_stages: Sequence[Q_Float],
+    ) -> Sequence[Q_IntTuple]:
+        compression_ratios: map[Optional[Q_IntTuple]] = map(
+            Compressor.get_compression_ratio_and_stage, overall_compression_ratio_stages
+        )
+        return [ratio for ratio in compression_ratios if ratio is not None]
+
+    @staticmethod
+    @ureg.wraps(("frac", None), "frac", strict=False)
+    def get_compression_ratio_and_stage(overall_compression_ratio: float) -> Optional[Q_IntTuple]:
         max_stages = len(_power)
-        compression_ratio_per_stages = []
-
-        for compression_ratio in overall_compression_ratio_stages:
-            for pow in _power:
-                if compression_ratio ** pow < max_stages:
-                    compression_ratio_per_stages.append(compression_ratio ** pow)
-                    break
-
-        return compression_ratio_per_stages
-
-    @staticmethod
-    def get_compression_ratio(overall_compression_ratio):
-        max_stages = len(_power)
-        result = 0
-
         for pow in _power:
-            if overall_compression_ratio ** pow < max_stages:
-                result = overall_compression_ratio ** pow
-                return result
+            if overall_compression_ratio**pow < max_stages:
+                return overall_compression_ratio**pow, int(1 / pow)
 
     @staticmethod
-    def get_num_of_compression_stages(overall_compression_ratio_stages):
-        num_of_compression_stages = []
-        compression_ratio_per_stages = Compressor.get_compression_ratio_stages(overall_compression_ratio_stages)
-
-        for overall_compression_ratio, compression_ratio in \
-                zip(overall_compression_ratio_stages, compression_ratio_per_stages):
-            for pow in _power:
-                if overall_compression_ratio ** pow == compression_ratio:
-                    num_of_compression_stages.append(int(1 / pow))
-                    break
-
-        return num_of_compression_stages
-
-    @staticmethod
-    def get_num_of_compression(overall_compression_ratio):
-        result = 0
-        compression_ratio = Compressor.get_compression_ratio(overall_compression_ratio)
-
-        for pow in _power:
-            if overall_compression_ratio ** pow == compression_ratio:
-                result = int(1 / pow)
-                return result
-
-    @staticmethod
-    def get_compressor_energy_consumption(field,
-                                          prime_mover_type,
-                                          eta_compressor,
-                                          overall_compression_ratio,
-                                          inlet_stream,
-                                          inlet_tp=None):
+    @ureg.wraps(("mmbtu/day", "degF", "psia"), (None, None, None, "frac", None, None))
+    def get_compressor_energy_consumption(
+        field,
+        prime_mover_type,
+        eta_compressor,
+        overall_compression_ratio,
+        inlet_stream: Stream,
+        inlet_tp: Optional[TemperaturePressure] = None,
+    ):
         """
         Calculate compressor energy consumption
 
@@ -119,20 +118,16 @@ class Compressor(OpgeeObject):
         :return:
         """
         energy_consumption = ureg.Quantity(0, "mmbtu/day")
-        tp = inlet_tp or inlet_stream.tp
+        tp: TemperaturePressure = inlet_tp or inlet_stream.tp
         inlet_temp, inlet_press = tp.get()
 
         if overall_compression_ratio < 1 or inlet_stream.has_zero_flow():
             return energy_consumption, inlet_temp, inlet_press
 
-        compression_ratio = Compressor.get_compression_ratio(overall_compression_ratio)
-        num_stages = Compressor.get_num_of_compression(overall_compression_ratio)
-        total_work, outlet_temp, outlet_press = Compressor.get_compressor_work_temp(field,
-                                                                                    inlet_temp,
-                                                                                    inlet_press,
-                                                                                    inlet_stream,
-                                                                                    compression_ratio,
-                                                                                    num_stages)
+        compression_ratio, num_stages = Compressor.get_compression_ratio_and_stage(overall_compression_ratio)
+        total_work, outlet_temp, outlet_press = Compressor.get_compressor_work_temp(
+            field, inlet_temp, inlet_press, inlet_stream, compression_ratio, num_stages
+        )
         volume_flow_rate_STP = field.gas.volume_flow_rate_STP(inlet_stream)
         total_energy = total_work * volume_flow_rate_STP
         brake_horse_power = total_energy / eta_compressor

--- a/opgee/processes/crude_oil_dewatering.py
+++ b/opgee/processes/crude_oil_dewatering.py
@@ -6,12 +6,12 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..core import TemperaturePressure
 from ..error import OpgeeException
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_LIQUID
+from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/crude_oil_dewatering.py
+++ b/opgee/processes/crude_oil_dewatering.py
@@ -6,12 +6,12 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..core import TemperaturePressure
 from ..error import OpgeeException
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_LIQUID
-from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/crude_oil_storage.py
+++ b/opgee/processes/crude_oil_storage.py
@@ -6,12 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
-from ..stream import PHASE_GAS
-from ..stream import Stream
+from ..stream import PHASE_GAS, Stream
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/crude_oil_storage.py
+++ b/opgee/processes/crude_oil_storage.py
@@ -6,11 +6,12 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
-from ..stream import PHASE_GAS, Stream
-from ..units import ureg
+from ..stream import PHASE_GAS
+from ..stream import Stream
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/demethanizer.py
+++ b/opgee/processes/demethanizer.py
@@ -8,15 +8,16 @@
 #
 import pandas as pd
 
+from ..units import ureg
 from ..core import STP, TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
-from ..process import Process, run_corr_eqns
+from ..process import Process
+from ..process import run_corr_eqns
 from ..stream import PHASE_GAS, Stream
-from ..units import ureg
 from .compressor import Compressor
-from .shared import get_bounded_value, get_energy_carrier, predict_blower_energy_use
+from .shared import get_energy_carrier, predict_blower_energy_use, get_bounded_value
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/demethanizer.py
+++ b/opgee/processes/demethanizer.py
@@ -8,16 +8,15 @@
 #
 import pandas as pd
 
-from .. import ureg
 from ..core import STP, TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
-from ..process import Process
-from ..process import run_corr_eqns
+from ..process import Process, run_corr_eqns
 from ..stream import PHASE_GAS, Stream
+from ..units import ureg
 from .compressor import Compressor
-from .shared import get_energy_carrier, predict_blower_energy_use, get_bounded_value
+from .shared import get_bounded_value, get_energy_carrier, predict_blower_energy_use
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/downhole_pump.py
+++ b/opgee/processes/downhole_pump.py
@@ -8,13 +8,13 @@
 #
 import numpy as np
 
-from .. import ureg
+from ..combine_streams import combine_streams
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
-from ..stream import Stream, PHASE_GAS
-from ..combine_streams import combine_streams
+from ..stream import PHASE_GAS, Stream
+from ..units import ureg
 from .shared import get_energy_carrier, get_energy_consumption_stages
 
 _logger = getLogger(__name__)

--- a/opgee/processes/downhole_pump.py
+++ b/opgee/processes/downhole_pump.py
@@ -8,13 +8,13 @@
 #
 import numpy as np
 
-from ..combine_streams import combine_streams
+from ..units import ureg
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
-from ..stream import PHASE_GAS, Stream
-from ..units import ureg
+from ..stream import Stream, PHASE_GAS
+from ..combine_streams import combine_streams
 from .shared import get_energy_carrier, get_energy_consumption_stages
 
 _logger = getLogger(__name__)

--- a/opgee/processes/drilling.py
+++ b/opgee/processes/drilling.py
@@ -8,12 +8,12 @@
 #
 import numpy as np
 
-from .. import ureg
 from ..emissions import EM_LAND_USE
 from ..energy import EN_DIESEL
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/drilling.py
+++ b/opgee/processes/drilling.py
@@ -8,12 +8,12 @@
 #
 import numpy as np
 
+from ..units import ureg
 from ..emissions import EM_LAND_USE
 from ..energy import EN_DIESEL
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/exploration.py
+++ b/opgee/processes/exploration.py
@@ -8,10 +8,10 @@
 #
 import math
 
-from .. import ureg
 from ..energy import EN_DIESEL
 from ..log import getLogger
 from ..process import Process
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/exploration.py
+++ b/opgee/processes/exploration.py
@@ -8,10 +8,10 @@
 #
 import math
 
+from ..units import ureg
 from ..energy import EN_DIESEL
 from ..log import getLogger
 from ..process import Process
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/gas_dehydration.py
+++ b/opgee/processes/gas_dehydration.py
@@ -8,14 +8,13 @@
 #
 import numpy as np
 
-from .. import ureg
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY
+from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS
 from ..error import OpgeeException
 from ..log import getLogger
-from ..process import Process
-from ..process import run_corr_eqns
+from ..process import Process, run_corr_eqns
 from ..thermodynamics import ChemicalInfo
+from ..units import ureg
 from .shared import get_bounded_value, predict_blower_energy_use
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_dehydration.py
+++ b/opgee/processes/gas_dehydration.py
@@ -8,13 +8,14 @@
 #
 import numpy as np
 
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS
+from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY
 from ..error import OpgeeException
 from ..log import getLogger
-from ..process import Process, run_corr_eqns
+from ..process import Process
+from ..process import run_corr_eqns
 from ..thermodynamics import ChemicalInfo
-from ..units import ureg
 from .shared import get_bounded_value, predict_blower_energy_use
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_gathering.py
+++ b/opgee/processes/gas_gathering.py
@@ -7,12 +7,11 @@
 # See LICENSE.txt for license details.
 #
 import math
-
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/gas_gathering.py
+++ b/opgee/processes/gas_gathering.py
@@ -7,11 +7,12 @@
 # See LICENSE.txt for license details.
 #
 import math
-from .. import ureg
+
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/gas_lifting_compressor.py
+++ b/opgee/processes/gas_lifting_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
+from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_lifting_compressor.py
+++ b/opgee/processes/gas_lifting_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
-from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_partition.py
+++ b/opgee/processes/gas_partition.py
@@ -6,15 +6,17 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..combine_streams import combine_streams
-from ..core import STP, TemperaturePressure
-from ..energy import EN_NATURAL_GAS
+from ..core import STP
+from ..core import TemperaturePressure
 from ..error import OpgeeException
-from ..import_export import N2, NATURAL_GAS, CO2_Flooding
+from ..energy import EN_NATURAL_GAS
+from ..import_export import N2, CO2_Flooding, NATURAL_GAS
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS, Stream
-from ..units import ureg
+
 from .shared import get_init_lifting_stream
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_partition.py
+++ b/opgee/processes/gas_partition.py
@@ -6,17 +6,15 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..combine_streams import combine_streams
-from ..core import STP
-from ..core import TemperaturePressure
-from ..error import OpgeeException
+from ..core import STP, TemperaturePressure
 from ..energy import EN_NATURAL_GAS
-from ..import_export import N2, CO2_Flooding, NATURAL_GAS
+from ..error import OpgeeException
+from ..import_export import N2, NATURAL_GAS, CO2_Flooding
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS, Stream
-
+from ..units import ureg
 from .shared import get_init_lifting_stream
 
 _logger = getLogger(__name__)

--- a/opgee/processes/gas_reinjection_compressor.py
+++ b/opgee/processes/gas_reinjection_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process
-from ..units import ureg
 from .compressor import Compressor
 from .shared import get_energy_carrier
 

--- a/opgee/processes/gas_reinjection_compressor.py
+++ b/opgee/processes/gas_reinjection_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process
+from ..units import ureg
 from .compressor import Compressor
 from .shared import get_energy_carrier
 

--- a/opgee/processes/heavy_oil_upgrading.py
+++ b/opgee/processes/heavy_oil_upgrading.py
@@ -8,15 +8,14 @@
 #
 import pandas as pd
 
-from .. import ureg
 from ..core import STP
 from ..emissions import EM_FLARING
-from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_UPG_PROC_GAS, EN_PETCOKE
+from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS, EN_PETCOKE, EN_UPG_PROC_GAS
 from ..import_export import ELECTRICITY, H2
 from ..log import getLogger
 from ..process import Process
-from ..stream import PHASE_GAS
-from ..stream import Stream
+from ..stream import PHASE_GAS, Stream
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/heavy_oil_upgrading.py
+++ b/opgee/processes/heavy_oil_upgrading.py
@@ -8,14 +8,15 @@
 #
 import pandas as pd
 
+from ..units import ureg
 from ..core import STP
 from ..emissions import EM_FLARING
-from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS, EN_PETCOKE, EN_UPG_PROC_GAS
+from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_UPG_PROC_GAS, EN_PETCOKE
 from ..import_export import ELECTRICITY, H2
 from ..log import getLogger
 from ..process import Process
-from ..stream import PHASE_GAS, Stream
-from ..units import ureg
+from ..stream import PHASE_GAS
+from ..stream import Stream
 
 _logger = getLogger(__name__)
 
@@ -31,7 +32,7 @@ class HeavyOilUpgrading(Process):
 
         self._required_outputs = [
             "oil for storage",
-            "process gas",
+            "gas",
             "gas for flaring",
             "petrocoke",
         ]
@@ -122,7 +123,7 @@ class HeavyOilUpgrading(Process):
 
         proc_gas_exported_mass_rate = calculate_mass_rate_from_volume_rate(proc_gas_exported, self.upgrader_gas_comp)
         proc_gas_to_H2_mass_rate = calculate_mass_rate_from_volume_rate(proc_gas_to_H2, self.upgrader_gas_comp)
-        output_proc_gas = self.find_output_stream("process gas")
+        output_proc_gas = self.find_output_stream("gas")
         output_proc_gas.set_rates_from_series(proc_gas_exported_mass_rate, PHASE_GAS)
         output_proc_gas.set_tp(STP)
 

--- a/opgee/processes/pre_membrane_chiller.py
+++ b/opgee/processes/pre_membrane_chiller.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/pre_membrane_chiller.py
+++ b/opgee/processes/pre_membrane_chiller.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..energy import EN_ELECTRICITY
 from ..log import getLogger
 from ..process import Process
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/pre_membrane_compressor.py
+++ b/opgee/processes/pre_membrane_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
+from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/pre_membrane_compressor.py
+++ b/opgee/processes/pre_membrane_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
-from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/reservoir_well_interface.py
+++ b/opgee/processes/reservoir_well_interface.py
@@ -8,11 +8,11 @@
 #
 import numpy as np
 
-from ..core import STP, TemperaturePressure
+from ..units import ureg
+from ..core import TemperaturePressure, STP
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS
-from ..units import ureg
 
 _logger = getLogger(__name__)  # data logging
 

--- a/opgee/processes/reservoir_well_interface.py
+++ b/opgee/processes/reservoir_well_interface.py
@@ -8,11 +8,11 @@
 #
 import numpy as np
 
-from .. import ureg
-from ..core import TemperaturePressure, STP
+from ..core import STP, TemperaturePressure
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS
+from ..units import ureg
 
 _logger = getLogger(__name__)  # data logging
 

--- a/opgee/processes/ryan_holmes.py
+++ b/opgee/processes/ryan_holmes.py
@@ -6,12 +6,12 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_DIESEL, EN_NATURAL_GAS
+from ..energy import EN_NATURAL_GAS, EN_DIESEL
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/ryan_holmes.py
+++ b/opgee/processes/ryan_holmes.py
@@ -6,12 +6,12 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
-from ..energy import EN_NATURAL_GAS, EN_DIESEL
+from ..energy import EN_DIESEL, EN_NATURAL_GAS
 from ..log import getLogger
 from ..process import Process
 from ..stream import PHASE_GAS
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/separation.py
+++ b/opgee/processes/separation.py
@@ -239,16 +239,14 @@ class Separation(Process):
         overall_compression_ratio_stages = [self.pressure_after_boosting /
                                             pressure_of_stages[stage] for stage in range(self.num_of_stages)]
         compression_ratio_per_stages = Compressor.get_compression_ratio_stages(overall_compression_ratio_stages)
-        num_of_compression_stages = Compressor.get_num_of_compression_stages(overall_compression_ratio_stages)  # (int)
 
         brake_horsepower_of_stages = []
-        for (inlet_temp, inlet_press, compression_ratio,
-             gas_compression_volume, num_of_compression) \
+        for (inlet_temp, inlet_press, (compression_ratio, num_of_compression),
+             gas_compression_volume) \
                 in zip(temperature_of_stages,
                        pressure_of_stages,
                        compression_ratio_per_stages,
-                       gas_compression_volume_stages,
-                       num_of_compression_stages):
+                       gas_compression_volume_stages):
             work_sum, _, _ = Compressor.get_compressor_work_temp(field, inlet_temp, inlet_press,
                                                                  gas_stream, compression_ratio, num_of_compression)
             horsepower = work_sum * gas_compression_volume

--- a/opgee/processes/shared.py
+++ b/opgee/processes/shared.py
@@ -6,10 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
-from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_DIESEL, EN_RESID
+from pint.facets.plain import PlainQuantity
+
+from opgee.units import ureg
+
+from ..energy import EN_DIESEL, EN_ELECTRICITY, EN_NATURAL_GAS, EN_RESID
 from ..error import OpgeeException
-from ..stream import Stream, PHASE_GAS
+from ..stream import PHASE_GAS, Stream
 
 _slope = {"NG_engine": -0.6035,
           "NG_turbine": -0.1279}
@@ -23,14 +26,14 @@ _maxBHP = {"NG_engine": 2800.0,
            "Electric_motor": 1000.0}
 
 
-def get_efficiency(prime_mover_type, brake_horsepower):
+@ureg.wraps("btu/hp/hr", (None, "hp"), strict=False)
+def get_efficiency(prime_mover_type: str, brake_horsepower=ureg.Quantity(0., 'hp')):
     """
 
-    :param prime_mover_type:
-    :param brake_horsepower:
-    :return: (pint.Quantity) efficiency in units of "btu/horsepower/hour"
+    :param prime_mover_type: (str)
+    :param brake_horsepower: (float)
+    :return: (float) efficiency in units of "btu/horsepower/hour"
     """
-    brake_horsepower = brake_horsepower.to("horsepower").m
     brake_horsepower = min(_maxBHP[prime_mover_type], brake_horsepower)
 
     if prime_mover_type == "Electric_motor":
@@ -40,7 +43,7 @@ def get_efficiency(prime_mover_type, brake_horsepower):
     else:
         efficiency = _slope[prime_mover_type] * brake_horsepower + _intercept[prime_mover_type]
 
-    return ureg.Quantity(efficiency, "btu/horsepower/hour")
+    return efficiency
 
 
 def get_init_lifting_stream(gas,
@@ -127,11 +130,10 @@ def get_energy_consumption_stages(prime_mover_type, brake_horsepower_of_stages):
     return energy_consumption_of_stages
 
 
-def get_energy_consumption(prime_mover_type, brake_horsepower):
+@ureg.check(None, ureg.hp)
+def get_energy_consumption(prime_mover_type: str, brake_horsepower: PlainQuantity):
     eff = get_efficiency(prime_mover_type, brake_horsepower)
-    energy_consumption = (brake_horsepower * eff).to("mmBtu/day")
-
-    return energy_consumption
+    return (brake_horsepower * eff).to("mmBtu/day")
 
 
 def get_bounded_value(value, name, variable_bound_dict):

--- a/opgee/processes/shared.py
+++ b/opgee/processes/shared.py
@@ -6,13 +6,10 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from pint.facets.plain import PlainQuantity
-
-from opgee.units import ureg
-
-from ..energy import EN_DIESEL, EN_ELECTRICITY, EN_NATURAL_GAS, EN_RESID
+from ..units import ureg
+from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY, EN_DIESEL, EN_RESID
 from ..error import OpgeeException
-from ..stream import PHASE_GAS, Stream
+from ..stream import Stream, PHASE_GAS
 
 _slope = {"NG_engine": -0.6035,
           "NG_turbine": -0.1279}
@@ -26,14 +23,14 @@ _maxBHP = {"NG_engine": 2800.0,
            "Electric_motor": 1000.0}
 
 
-@ureg.wraps("btu/hp/hr", (None, "hp"), strict=False)
-def get_efficiency(prime_mover_type: str, brake_horsepower=ureg.Quantity(0., 'hp')):
+def get_efficiency(prime_mover_type, brake_horsepower):
     """
 
-    :param prime_mover_type: (str)
-    :param brake_horsepower: (float)
-    :return: (float) efficiency in units of "btu/horsepower/hour"
+    :param prime_mover_type:
+    :param brake_horsepower:
+    :return: (pint.Quantity) efficiency in units of "btu/horsepower/hour"
     """
+    brake_horsepower = brake_horsepower.to("horsepower").m
     brake_horsepower = min(_maxBHP[prime_mover_type], brake_horsepower)
 
     if prime_mover_type == "Electric_motor":
@@ -43,7 +40,7 @@ def get_efficiency(prime_mover_type: str, brake_horsepower=ureg.Quantity(0., 'hp
     else:
         efficiency = _slope[prime_mover_type] * brake_horsepower + _intercept[prime_mover_type]
 
-    return efficiency
+    return ureg.Quantity(efficiency, "btu/horsepower/hour")
 
 
 def get_init_lifting_stream(gas,
@@ -130,10 +127,11 @@ def get_energy_consumption_stages(prime_mover_type, brake_horsepower_of_stages):
     return energy_consumption_of_stages
 
 
-@ureg.check(None, ureg.hp)
-def get_energy_consumption(prime_mover_type: str, brake_horsepower: PlainQuantity):
+def get_energy_consumption(prime_mover_type, brake_horsepower):
     eff = get_efficiency(prime_mover_type, brake_horsepower)
-    return (brake_horsepower * eff).to("mmBtu/day")
+    energy_consumption = (brake_horsepower * eff).to("mmBtu/day")
+
+    return energy_consumption
 
 
 def get_bounded_value(value, name, variable_bound_dict):

--- a/opgee/processes/sour_gas_compressor.py
+++ b/opgee/processes/sour_gas_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
+from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/sour_gas_compressor.py
+++ b/opgee/processes/sour_gas_compressor.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..processes.compressor import Compressor
-from ..units import ureg
 from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)

--- a/opgee/processes/steam_generation.py
+++ b/opgee/processes/steam_generation.py
@@ -6,13 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..core import TemperaturePressure
-from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY
+from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS
 from ..error import BalanceError
 from ..import_export import WATER
 from ..log import getLogger
 from ..process import Process
+from ..units import ureg
 from .shared import get_energy_consumption
 
 _logger = getLogger(__name__)

--- a/opgee/processes/steam_generation.py
+++ b/opgee/processes/steam_generation.py
@@ -6,13 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..core import TemperaturePressure
-from ..energy import EN_ELECTRICITY, EN_NATURAL_GAS
+from ..energy import EN_NATURAL_GAS, EN_ELECTRICITY
 from ..error import BalanceError
 from ..import_export import WATER
 from ..log import getLogger
 from ..process import Process
-from ..units import ureg
 from .shared import get_energy_consumption
 
 _logger = getLogger(__name__)

--- a/opgee/processes/steam_generator.py
+++ b/opgee/processes/steam_generator.py
@@ -8,9 +8,9 @@
 #
 import pandas as pd
 
-from .. import ureg
 from ..core import OpgeeObject
 from ..stream import PHASE_GAS
+from ..units import ureg
 
 
 class SteamGenerator(OpgeeObject):  # N.B. NOT a subclass of Process

--- a/opgee/processes/steam_generator.py
+++ b/opgee/processes/steam_generator.py
@@ -8,9 +8,9 @@
 #
 import pandas as pd
 
+from ..units import ureg
 from ..core import OpgeeObject
 from ..stream import PHASE_GAS
-from ..units import ureg
 
 
 class SteamGenerator(OpgeeObject):  # N.B. NOT a subclass of Process

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -8,12 +8,12 @@
 #
 import math
 
-from .compressor import Compressor
-from .shared import get_energy_carrier
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
+from .compressor import Compressor
+from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)
 
@@ -75,7 +75,7 @@ class TransmissionCompressor(Process):
         num_compressor_stations = math.ceil(self.transmission_dist / self.transmission_freq)
 
         # initial compressor properties
-        overall_compression_ratio_init = station_outlet_press / input.tp.P
+        overall_compression_ratio_init = station_outlet_press.to("psi_absolute") / input.tp.P
         energy_consumption_init, output_temp_init, output_press_init = \
             Compressor.get_compressor_energy_consumption(
                 self.field,
@@ -85,7 +85,7 @@ class TransmissionCompressor(Process):
                 input)
 
         # Along-pipeline booster compressor properties
-        overall_compression_ratio_booster = station_outlet_press / self.transmission_inlet_press
+        overall_compression_ratio_booster = station_outlet_press.to("psi_absolute") / self.transmission_inlet_press
         energy_consumption_booster, output_temp_booster, output_press_booster = \
             Compressor.get_compressor_energy_consumption(
                 self.field,

--- a/opgee/processes/transmission_compressor.py
+++ b/opgee/processes/transmission_compressor.py
@@ -8,12 +8,12 @@
 #
 import math
 
+from .compressor import Compressor
+from .shared import get_energy_carrier
 from ..core import TemperaturePressure
 from ..emissions import EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
-from .compressor import Compressor
-from .shared import get_energy_carrier
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/transport_energy.py
+++ b/opgee/processes/transport_energy.py
@@ -8,10 +8,10 @@
 #
 import pandas as pd
 
-from .. import ureg
 from ..core import OpgeeObject
-from ..error import OpgeeException
 from ..energy import EN_DIESEL
+from ..error import OpgeeException
+from ..units import ureg
 
 
 class TransportEnergy(OpgeeObject):

--- a/opgee/processes/transport_energy.py
+++ b/opgee/processes/transport_energy.py
@@ -8,10 +8,10 @@
 #
 import pandas as pd
 
-from ..core import OpgeeObject
-from ..energy import EN_DIESEL
-from ..error import OpgeeException
 from ..units import ureg
+from ..core import OpgeeObject
+from ..error import OpgeeException
+from ..energy import EN_DIESEL
 
 
 class TransportEnergy(OpgeeObject):

--- a/opgee/processes/venting.py
+++ b/opgee/processes/venting.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
-from ..emissions import EM_VENTING, EM_FUGITIVES
+from ..emissions import EM_FUGITIVES, EM_VENTING
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/venting.py
+++ b/opgee/processes/venting.py
@@ -6,11 +6,11 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from ..emissions import EM_FUGITIVES, EM_VENTING
+from ..units import ureg
+from ..emissions import EM_VENTING, EM_FUGITIVES
 from ..log import getLogger
 from ..process import Process
 from ..stream import Stream
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/water_injection.py
+++ b/opgee/processes/water_injection.py
@@ -15,11 +15,11 @@
 #
 import numpy as np
 
-from .shared import get_energy_carrier, get_energy_consumption
 from ..error import OpgeeException
 from ..log import getLogger
 from ..process import Process
-from .. import ureg
+from ..units import ureg
+from .shared import get_energy_carrier, get_energy_consumption
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/water_injection.py
+++ b/opgee/processes/water_injection.py
@@ -15,11 +15,11 @@
 #
 import numpy as np
 
+from .shared import get_energy_carrier, get_energy_consumption
 from ..error import OpgeeException
 from ..log import getLogger
 from ..process import Process
 from ..units import ureg
-from .shared import get_energy_carrier, get_energy_consumption
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/water_treatment.py
+++ b/opgee/processes/water_treatment.py
@@ -6,13 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
+from ..units import ureg
 from ..core import TemperaturePressure
 from ..energy import EN_ELECTRICITY
 from ..error import OpgeeException
 from ..import_export import WATER
 from ..log import getLogger
 from ..process import Process
-from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/processes/water_treatment.py
+++ b/opgee/processes/water_treatment.py
@@ -6,13 +6,13 @@
 # Copyright (c) 2021-2022 The Board of Trustees of the Leland Stanford Junior University.
 # See LICENSE.txt for license details.
 #
-from .. import ureg
 from ..core import TemperaturePressure
 from ..energy import EN_ELECTRICITY
 from ..error import OpgeeException
 from ..import_export import WATER
 from ..log import getLogger
 from ..process import Process
+from ..units import ureg
 
 _logger = getLogger(__name__)
 

--- a/opgee/stream.py
+++ b/opgee/stream.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pint
 import pint_pandas
 
-from . import ureg
+from .units import ureg
 from .attributes import AttributeMixin
 from .core import XmlInstantiable, elt_name, magnitude, TemperaturePressure
 from .error import OpgeeException, ModelValidationError

--- a/opgee/stream.py
+++ b/opgee/stream.py
@@ -13,9 +13,9 @@ import pandas as pd
 import pint
 import pint_pandas
 
-from .units import ureg
+from .units import ureg, magnitude
 from .attributes import AttributeMixin
-from .core import XmlInstantiable, elt_name, magnitude, TemperaturePressure
+from .core import XmlInstantiable, elt_name, TemperaturePressure
 from .error import OpgeeException, ModelValidationError
 from .log import getLogger
 from .table_manager import TableManager
@@ -144,6 +144,8 @@ class Stream(AttributeMixin, XmlInstantiable):
     _extensions = {}
 
     _units = ureg.Unit("tonne/day")
+    
+    tp: TemperaturePressure
 
     def __init__(
         self,

--- a/opgee/thermodynamics.py
+++ b/opgee/thermodynamics.py
@@ -8,16 +8,16 @@
 #
 import math
 
-import numpy as np
 import pandas as pd
+import numpy as np
 import pint
 from pyXSteam.XSteam import XSteam
 from thermosteam import Chemical, IdealMixture
 
-from .core import STP, OpgeeObject, TemperaturePressure
+from .units import ureg
+from .core import OpgeeObject, STP, TemperaturePressure
 from .error import ModelValidationError
 from .stream import PHASE_GAS, PHASE_LIQUID, PHASE_SOLID, Stream
-from .units import ureg
 
 
 class ChemicalInfo(OpgeeObject):

--- a/opgee/thermodynamics.py
+++ b/opgee/thermodynamics.py
@@ -8,16 +8,16 @@
 #
 import math
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pint
 from pyXSteam.XSteam import XSteam
 from thermosteam import Chemical, IdealMixture
 
-from . import ureg
-from .core import OpgeeObject, STP, TemperaturePressure
+from .core import STP, OpgeeObject, TemperaturePressure
 from .error import ModelValidationError
-from .stream import PHASE_LIQUID, Stream, PHASE_GAS, PHASE_SOLID
+from .stream import PHASE_GAS, PHASE_LIQUID, PHASE_SOLID, Stream
+from .units import ureg
 
 
 class ChemicalInfo(OpgeeObject):
@@ -987,6 +987,7 @@ class Gas(AbstractSubstance):
         return result.to("frac")
 
     @staticmethod
+    @ureg.wraps("frac", ("frac", "frac"))
     def Z_factor(reduced_temperature, reduced_pressure):
         """
         Calculate the compressibility factor (Z) for a given reduced temperature and reduced pressure
@@ -1002,11 +1003,8 @@ class Gas(AbstractSubstance):
             pint.Quantity: Compressibility factor (Z) as a Pint Quantity object (dimensionless fraction) for the given reduced temperature and reduced pressure.
 
         """
-        tr = reduced_temperature.to("frac").m
-        pr = reduced_pressure.to("frac").m
-
-        a = 0.42748 * (pr / tr ** 2.5)
-        b = 0.08664 * (pr / tr)
+        a = 0.42748 * (reduced_pressure / reduced_temperature ** 2.5)
+        b = 0.08664 * (reduced_pressure / reduced_temperature)
 
         alpha = (1 / 3) * (3 * (a - b - b ** 2) - 1)
         beta = (1 / 27) * (-2 + (9 * (a - b - b ** 2)) - (27 * a * b))

--- a/opgee/tool.py
+++ b/opgee/tool.py
@@ -322,16 +322,6 @@ def opg(cmdline):
     argv = shlex.split(cmdline)
     main(argv)
 
-# Code in function moved to constants.py
-# def load_pint_registry():
-#     from .units import ureg
-#     from .pkg_utils import resourceStream
-#
-#     stream = resourceStream('etc/units.txt')
-#     lines = [line.strip() for line in stream.readlines()]
-#     ureg.load_definitions(lines)
-#     pint.set_application_registry(ureg)
-
 def main(argv=None, raiseError=False):
     # load_pint_registry()
 

--- a/opgee/tool.py
+++ b/opgee/tool.py
@@ -324,7 +324,7 @@ def opg(cmdline):
 
 # Code in function moved to constants.py
 # def load_pint_registry():
-#     from . import ureg
+#     from .units import ureg
 #     from .pkg_utils import resourceStream
 #
 #     stream = resourceStream('etc/units.txt')

--- a/opgee/units.py
+++ b/opgee/units.py
@@ -1,0 +1,106 @@
+from collections.abc import Callable
+from typing import (
+    Final,
+    Optional,
+    TypeVar,
+)
+
+import pint
+from pint.registry import ApplicationRegistry
+
+from opgee.error import OpgeeException
+from opgee.log import getLogger
+from opgee.pkg_utils import resourceStream
+
+FRAC = "frac"
+T = TypeVar("T", bound=Callable)
+
+_logger = getLogger(__name__)
+
+def _iif(fn: Callable[[], T]) -> T:
+    """
+    Simple decorator to define an immediately invoked function. Similar to
+    JS/TS `(function () {})()`
+
+    :param fn: Any callable that returns a Callable
+    :type fn: Callable[[], T]
+    :return: The return value from the passed Callable
+    :rtype: T
+    """
+    return fn()
+
+
+@_iif
+def get_ureg() -> Callable[[], ApplicationRegistry]:
+    """
+    Always return the same instance of OPGEE's `pint.ApplicationRegistry`.
+
+    :return: callable to fetch the ApplicationRegistry instance
+    :rtype: Callable[[], ApplicationRegistry]
+    """
+    _ar: Optional[ApplicationRegistry] = None
+
+    def _ret() -> ApplicationRegistry:
+        nonlocal _ar
+        if _ar is None:
+            _ar = pint.get_application_registry()
+            del _ar._units["bbl"]
+            stream = resourceStream("etc/units.txt")
+            lines = [line.strip() for line in stream.readlines()]
+            _ar.load_definitions(lines)
+        return _ar
+
+    return _ret
+
+
+ureg: Final[ApplicationRegistry] = get_ureg()
+
+Qty = ureg.Quantity
+
+# to avoid redundantly reporting bad units
+_undefined_units = {}
+
+def validate_unit(unit):
+    """
+    Return the ``pint.Unit`` associated with the string ``unit``, or ``None``
+    if ``unit`` is ``None`` or not in the unit registry.
+
+    :param unit: (str) a string representation of a ``pint.Unit``
+
+    :return: (pint.Unit or None)
+    """
+    if not unit:
+        return None
+
+    if unit in ureg:
+        return ureg.Unit(unit)
+
+    if unit not in _undefined_units:
+        _logger.warning(f"Unit '{unit}' is not in the UnitRegistry")
+        _undefined_units[unit] = 1
+
+    return None
+
+
+def magnitude(value, units=None):
+    """
+    Return the magnitude of ``value``. If ``value`` is a ``pint.Quantity`` and
+    ``units`` is not None, check that ``value`` has the expected units and
+    return the magnitude of ``value``. If ``value`` is not a ``pint.Quantity``,
+    just return it.
+
+    :param value: (float or pint.Quantity) the value for which we return the magnitude.
+    :param units: (None or pint.Unit) the expected units
+    :return: the magnitude of `value`
+    """
+    if isinstance(value, ureg.Quantity):
+        # if optional units are provided, validate them
+        if units:
+            if not isinstance(units, pint.Unit):
+                units = ureg.Unit(units)
+            if value.units != units:
+                raise OpgeeException(f"magnitude: value {value} units are not {units}")
+
+        return value.m
+    else:
+        return value

--- a/opgee/utils.py
+++ b/opgee/utils.py
@@ -267,22 +267,6 @@ def roundup(value, digits):
     return round(value + 0.5, digits)
 
 
-def mkdirs(newdir, mode=0o770):
-    """
-    Try to create the full path `newdir` and ignore the error if it already exists.
-
-    :param newdir: the directory to create (along with any needed parent directories)
-    :return: nothing
-    """
-    import errno  # PyCharm thinks this doesn't exist but it does.
-
-    try:
-        os.makedirs(newdir, mode)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-
-
 def loadModuleFromPath(module_path, raiseError=True):
     """
     Load a module from a '.py' or '.pyc' file from a path that ends in the
@@ -325,7 +309,7 @@ def loadModuleFromPath(module_path, raiseError=True):
     return module
 
 
-def getResource(relpath):
+def getResource(relpath: str):
     """
     Extract a resource (e.g., file) from the given relative path in
     the pygcam package.
@@ -337,11 +321,9 @@ def getResource(relpath):
     import pkgutil
 
     try:
-        contents = pkgutil.get_data('opgee', relpath)
+        return pkgutil.get_data('opgee', relpath)
     except FileNotFoundError as e:
         raise OpgeeException(f"Resource '{relpath}' was not found in the opgee package: {e}")
-
-    return contents.decode('utf-8')
 
 
 def dequantify_dataframe(df):

--- a/tests/files/test_model.xml
+++ b/tests/files/test_model.xml
@@ -112,6 +112,7 @@
 		<FieldRef name="test_SourGasInjection"/>
 		<FieldRef name="test_VRUCompressor"/>
 		<FieldRef name="test_GasReinjectionCompressor"/>
+		<FieldRef name="test_TransmissionCompressor"/>
 		<FieldRef name="test_N2Flooding"/>
 		<FieldRef name="test_CO2Flooding"/>
 		<FieldRef name="test_NGFlooding_onsite_gas"/>
@@ -894,6 +895,37 @@
 		</Stream>
 
 	</Field>
+	<Field name="test_TransmissionCompressor">
+		<Process class="Before"/>
+		<Process class="TransmissionCompressor"/>
+		<Process class="Boundary" boundary="Production"/>
+		<Stream src="Before" dst="TransmissionCompressor">
+			<Contains>gas</Contains>
+			<Component name="CO2" phase="gas">119.35794</Component>
+			<Component name="H2" phase="gas">18.04195</Component>
+			<Component name="H2S" phase="gas">18.48612</Component>
+			<Component name="C1" phase="gas">108.77169</Component>
+			<Component name="C2" phase="gas">122.32514</Component>
+			<Component name="C3" phase="gas">119.59151</Component>
+			<Component name="C4" phase="gas">78.81646</Component>
+			<A name="temperature">60</A>
+			<A name="pressure">14.676</A>
+		</Stream>
+		<Stream src="TransmissionCompressor" dst="ProductionBoundary"
+			name="transmission gas for storage">
+			<Contains>gas for storage</Contains>
+		</Stream>
+
+		<Stream src="TransmissionCompressor" dst="ProductionBoundary"
+			name="transmission gas for LNG">
+			<Contains>LNG</Contains>
+		</Stream>
+
+		<Stream src="TransmissionCompressor" dst="ProductionBoundary"
+			name="transmission gas for distribution">
+			<Contains>gas for distribution</Contains>
+		</Stream>
+	</Field>
 
 	<Field name="test_GasLiftingCompressor">
 
@@ -1226,7 +1258,7 @@
 		</Stream>
 
 		<Stream src="HeavyOilUpgrading" dst="ProductionBoundary" name="process gas">
-			<Contains>process gas</Contains>
+			<Contains>gas</Contains>
 		</Stream>
 
 		<Stream src="HeavyOilUpgrading" dst="ProductionBoundary" name="petrocoke">

--- a/tests/processes/test_compressor.py
+++ b/tests/processes/test_compressor.py
@@ -1,0 +1,39 @@
+import functools
+
+import pytest
+from pint import DimensionalityError, Quantity
+
+from opgee.processes.compressor import Compressor
+from opgee.units import ureg
+
+Q_ = ureg.Quantity
+
+def test_get_compression_ratio():
+    overall_comp_ratio = Q_(25., 'kilopascal') / Q_(0.5, 'psia')
+    result = Compressor.get_compression_ratio_and_stage(overall_comp_ratio)
+    assert result is not None
+    _approx = functools.partial(pytest.approx, rel=10e-3, abs=10e-6)
+    comp_ratio, num_stages = result
+    assert comp_ratio.m == _approx(2.6929, rel=10E-3, abs=10E-6)
+    assert num_stages == 2
+    
+    # works with pure floats as well
+    result = Compressor.get_compression_ratio_and_stage(3 / 2)
+    assert result is not None
+    comp_ratio, num_stages = result
+    assert isinstance(comp_ratio, Quantity)
+    assert comp_ratio.m == 1.5
+    assert num_stages == 1
+    
+def test_get_compression_ratio_not_dimensionless():
+    overall_compression_ratio = Q_(1., 'kPa') / Q_(1., 'sec')
+    
+    with pytest.raises(DimensionalityError):
+        _ = Compressor.get_compression_ratio_and_stage(overall_compression_ratio)
+        
+def test_get_compression_ratio_stages_qtys():
+    ratios = [1., 1000., 0.558, 100]
+    comp_ratios = [Q_(r, "frac") for r in ratios]
+    result = Compressor.get_compression_ratio_stages(comp_ratios)
+    assert len(result) > 0
+    

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,6 +1,6 @@
 import pytest
 from lxml import etree as ET
-from opgee import ureg
+from opgee.units import ureg
 from opgee.analysis import Analysis
 from opgee.attributes import ClassAttrs, AttributeMixin, AttrDefs
 from opgee.core import instantiate_subelts

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 import pytest
-from opgee.units import ureg
-from opgee.core import magnitude, dict_from_list, validate_unit, XmlInstantiable, A, _undefined_units
+from opgee.units import ureg, magnitude, _undefined_units, validate_unit
+from opgee.core import dict_from_list, XmlInstantiable, A
 from opgee.error import OpgeeException, AbstractMethodError
 
 def test_magnitude_error():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,5 @@
 import pytest
-from opgee import ureg
+from opgee.units import ureg
 from opgee.core import magnitude, dict_from_list, validate_unit, XmlInstantiable, A, _undefined_units
 from opgee.error import OpgeeException, AbstractMethodError
 

--- a/tests/test_emissions.py
+++ b/tests/test_emissions.py
@@ -1,6 +1,6 @@
 import pytest
 import pandas as pd
-from opgee import ureg
+from opgee.units import ureg
 from opgee.emissions import Emissions, EM_FUGITIVES, EM_FLARING, EM_LAND_USE, EmissionsError
 from opgee.error import OpgeeException
 

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,4 +1,4 @@
-from opgee import ureg
+from opgee.units import ureg
 from opgee.energy import (Energy, EN_DIESEL, EN_NATURAL_GAS, EN_RESID,
                           EN_PETCOKE, EN_CRUDE_OIL, EN_ELECTRICITY)
 from opgee.error import OpgeeException

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,5 +1,5 @@
 import pytest
-from opgee import ureg
+from opgee.units import ureg
 from .utils_for_tests import load_model_from_str
 from opgee.error import XmlFormatError
 from .utils_for_tests import load_test_model

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -24,6 +24,7 @@ def test_graphing(opgee_main, args):
         opgee_main.run(None, args)
         good = True
     except Exception as e:
+        import pdb; pdb.set_trace()
         # print(e)
         good = False
 

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -1,4 +1,4 @@
-from opgee import ureg
+from opgee.units import ureg
 from opgee.import_export import ImportExport, ELECTRICITY, NATURAL_GAS
 
 def test_import():

--- a/tests/test_impute.py
+++ b/tests/test_impute.py
@@ -2,7 +2,7 @@ import pytest
 from opgee.error import OpgeeException
 from opgee.process import Process
 from .utils_for_tests import load_test_model
-from opgee import ureg
+from opgee.units import ureg
 
 class CopyingProcess(Process):
     def run(self, analysis):

--- a/tests/test_intermediate_boundary.py
+++ b/tests/test_intermediate_boundary.py
@@ -1,5 +1,5 @@
 import pytest
-from opgee import ureg
+from opgee.units import ureg
 from opgee.model_file import ModelFile
 from opgee.process import Process
 from opgee.combine_streams import combine_streams

--- a/tests/test_opgee_xml.py
+++ b/tests/test_opgee_xml.py
@@ -1,6 +1,6 @@
 import pytest
 
-from opgee import ureg
+from opgee.units import ureg
 from opgee.model_file import ModelFile
 from tests.utils_for_tests import path_to_test_file
 

--- a/tests/test_process_loop.py
+++ b/tests/test_process_loop.py
@@ -1,4 +1,4 @@
-from opgee import ureg
+from opgee.units import ureg
 from opgee.stream import Stream, PHASE_LIQUID
 from opgee.process import Process
 from .utils_for_tests import load_test_model

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -350,6 +350,15 @@ def test_GasReinjectionCompressor(test_model):
     total = proc.energy.data.sum()
     expected = ureg.Quantity(64913.96925930, "mmbtu/day")
     assert approx_equal(total, expected, rel=10e-3)
+    
+def test_TransmissionCompressor(test_model):
+    analysis = test_model.get_analysis('test_gas_processes')
+    field = analysis.get_field('test_TransmissionCompressor')
+    field.run(analysis)
+    proc = field.find_process("TransmissionCompressor")
+    total = proc.energy.data.sum()
+    expected = ureg.Quantity(1733.3619, "mmbtu/day")
+    assert approx_equal(total, expected, rel=10e-3)
 
 
 def test_N2Flooding(test_model):
@@ -698,6 +707,3 @@ def test_CrudeOilTransport():
     total = proc.find_output_stream("oil").liquid_flow_rate("oil")
     expected = ureg.Quantity(100.0, "tonne/day")
     assert approx_equal(total, expected)
-
-
-

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pytest
-from opgee import ureg
+from opgee.units import ureg
 from opgee.energy import EN_NATURAL_GAS, EN_CRUDE_OIL
 from opgee.emissions import EM_FLARING
 from opgee.error import OpgeeException, ZeroEnergyFlowError

--- a/tests/test_smart_defaults.py
+++ b/tests/test_smart_defaults.py
@@ -1,4 +1,4 @@
-from opgee import ureg
+from opgee.units import ureg
 from .utils_for_tests import load_model_from_str
 
 template = """<?xml version='1.0' encoding='UTF-8'?>

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,7 +1,7 @@
 import pytest
 from opgee.error import OpgeeException
 from opgee.process import Process
-from opgee import ureg
+from opgee.units import ureg
 
 from .utils_for_tests import load_test_model
 

--- a/tests/test_thermofunction.py
+++ b/tests/test_thermofunction.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from opgee.core import TemperaturePressure
 from opgee.stream import Stream, PHASE_GAS, PHASE_LIQUID
-from opgee import ureg
+from opgee.units import ureg
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from opgee import ureg
+from opgee.units import ureg
 from opgee.error import OpgeeException
 from opgee.utils import (getBooleanXML, coercible, mkdirs, loadModuleFromPath,
                          removeTree, parseTrialString, getResource)


### PR DESCRIPTION
Fixes #55 
- mode `ureg` and other unit related functions to `opgee/units.py` along with associated imports
  - this is the vast majority of the file changes
- use `ureg.wraps` for methods on `Compressor` and in some thermodynamics functions and remove unnecessary methods
  - update method usages in `TransmissionCompressor` and `Separation`
- update `TransmissionCompressor` with minor unit conversions
- revert some changes in #47 to address comments
