### PR TITLE
Fix/multiprocessing

### DIFF
--- a/opgee/built_ins/run_plugin.py
+++ b/opgee/built_ins/run_plugin.py
@@ -101,24 +101,24 @@ class RunCommand(SubcommandABC):
             help="""Comma-delimited list of field names to exclude from analysis""",
         )
 
-        parser.add_argument(
-            "-g",
-            "--post-proc-plugin",
-            metavar="PATH",
-            action="append",
-            default=[],
-            help="""Loads the post-processing plugin from the given path. The file
-                    must contain a single, valid subclass of ``opgee.post_process.PostProcess``.
-                    This arg can be specified multiple times to load multiple post-processing
-                    classes. They will be invoked in the order given on the command-line.""")
+        # parser.add_argument(
+        #     "-g",
+        #     "--post-proc-plugin",
+        #     metavar="PATH",
+        #     action="append",
+        #     default=[],
+        #     help="""Loads the post-processing plugin from the given path. The file
+        #             must contain a single, valid subclass of ``opgee.post_process.PostProcess``.
+        #             This arg can be specified multiple times to load multiple post-processing
+        #             classes. They will be invoked in the order given on the command-line.""")
 
-        parser.add_argument(
-            "-G",
-            "--no-post-proc-plugin-path",
-            action="store_true",
-            help="""Override the automatic loading of post-processing plugins from the path(s)
-                specified in config variable OPGEE.PostProcPluginPath. Specific plugins can
-                still be loaded using the --post-plugin argument.""")
+        # parser.add_argument(
+        #     "-G",
+        #     "--no-post-proc-plugin-path",
+        #     action="store_true",
+        #     help="""Override the automatic loading of post-processing plugins from the path(s)
+        #         specified in config variable OPGEE.PostProcPluginPath. Specific plugins can
+        #         still be loaded using the --post-plugin argument.""")
 
         parser.add_argument(
             "-i",
@@ -358,15 +358,6 @@ class RunCommand(SubcommandABC):
             packets = FieldPacket.packetize(
                 model_xml_file, analysis_name, field_names, packet_size
             )
-
-        # Load all plugins specified in OPGEE.PostProcPluginPath, unless user
-        # had overridden this using command line option --no-post-plugin-path
-        if not args.no_post_proc_plugin_path:
-            PostProcessor.load_all_plugins()
-
-        # Load explicitly specified post-processing plugins
-        for path in args.post_proc_plugin:
-            PostProcessor.load_plugin(path)
 
         results_list = []
         save_batches = batch_size is not None

--- a/opgee/built_ins/run_plugin.py
+++ b/opgee/built_ins/run_plugin.py
@@ -101,25 +101,6 @@ class RunCommand(SubcommandABC):
             help="""Comma-delimited list of field names to exclude from analysis""",
         )
 
-        # parser.add_argument(
-        #     "-g",
-        #     "--post-proc-plugin",
-        #     metavar="PATH",
-        #     action="append",
-        #     default=[],
-        #     help="""Loads the post-processing plugin from the given path. The file
-        #             must contain a single, valid subclass of ``opgee.post_process.PostProcess``.
-        #             This arg can be specified multiple times to load multiple post-processing
-        #             classes. They will be invoked in the order given on the command-line.""")
-
-        # parser.add_argument(
-        #     "-G",
-        #     "--no-post-proc-plugin-path",
-        #     action="store_true",
-        #     help="""Override the automatic loading of post-processing plugins from the path(s)
-        #         specified in config variable OPGEE.PostProcPluginPath. Specific plugins can
-        #         still be loaded using the --post-plugin argument.""")
-
         parser.add_argument(
             "-i",
             "--ignore-errors",

--- a/opgee/manager.py
+++ b/opgee/manager.py
@@ -260,8 +260,7 @@ class Manager(OpgeeObject):
             # Running with n_workers=1, threads_per_worker=2 resulted in weird runtime errors in Chemical.
             # self.cluster = cluster = SubprocessCluster(n_workers=1, threads_per_worker=num_engines, processes=False)
 
-            self.cluster = cluster = SubprocessCluster(n_workers=num_workers, threads_per_worker=1, processes=True,
-                                                  local_directory=local_dir)
+            self.cluster = cluster = SubprocessCluster(n_workers=num_workers, threads_per_worker=1, worker_kwargs=dict(local_directory=local_dir))
 
         else:
             raise McsSystemError(f"Unknown cluster type '{cluster_type}'. Valid options are 'slurm' and 'local'.")

--- a/opgee/post_processor.py
+++ b/opgee/post_processor.py
@@ -176,6 +176,7 @@ class PostProcessor(OpgeeObject):
 
     @classmethod
     def save_post_processor_results(cls, output_dir):
+        cls.load_all_plugins()
         for instance in cls.instances:
             instance.save(output_dir)
             instance.clear()

--- a/opgee/post_processor.py
+++ b/opgee/post_processor.py
@@ -56,6 +56,8 @@ class PostProcessor(OpgeeObject):
 
     # List subclass instances in order defined on the command-line
     instances = []
+    
+    _plugins_loaded: bool = False
 
     def __init__(self):
         pass
@@ -124,9 +126,12 @@ class PostProcessor(OpgeeObject):
         module = loadModuleFromPath(path)
 
         # Find the class, create an instance, and store it in cls.instances
-        for name, subcls in inspect.getmembers(module):
+        for _, subcls in inspect.getmembers(module):
             # Subclasses import PostProcessor, but we want only proper subclasses, not PostProcessor
             if subcls != PostProcessor and inspect.isclass(subcls) and issubclass(subcls, PostProcessor):
+                # ensure that only one instance of a given class is registered
+                if any((isinstance(inst, subcls) for inst in cls.instances)):
+                    continue
                 instance = subcls()
                 cls.instances.append(instance)
                 return instance
@@ -154,16 +159,18 @@ class PostProcessor(OpgeeObject):
 
         :return: nothing
         """
-        if not (dirs := cls._getPluginDirs()):
+        if not (dirs := cls._getPluginDirs()) or cls._plugins_loaded:
             return
 
         for dir in dirs:
             files = sorted(glob.glob(os.path.join(dir, '*.py')))
             for file in files:
                 cls.load_plugin(file)
+        cls._plugins_loaded = True
 
     @classmethod
     def run_post_processors(cls, analysis, field, result):
+        cls.load_all_plugins()
         for instance in cls.instances:
             instance.run(analysis, field, result)
 

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -630,7 +630,7 @@ class Process(AttributeMixin, XmlInstantiable):
         :return: (Stream, list or dict of Streams) depends on various keyword args
         :raises: OpgeeException if no processes handling `stream_type` are found and `raiseError` is True
         """
-        return self._find_streams_by_type(self.OUTPUT, stream_type, combine=combine, as_list=as_list,
+        return self._find_streams_by_type(self.OUTPUT, stream_type, regex=regex, combine=combine, as_list=as_list,
                                           raiseError=raiseError)
 
     def find_input_stream(self, stream_type, regex=False, raiseError=True) -> Union[Stream, None]:

--- a/opgee/processes/gas_partition.py
+++ b/opgee/processes/gas_partition.py
@@ -38,8 +38,8 @@ class GasPartition(Process):
         ]
 
         self._required_outputs = [
-            "gas",
-            # also two possible output streams below: "lifting gas" and "exported gas"
+            "exported gas",
+            # also two possible output streams below: "lifting gas" and "gas"
         ]
 
         if field.natural_gas_reinjection:

--- a/tests/test_post_proc_plugin.py
+++ b/tests/test_post_proc_plugin.py
@@ -70,6 +70,7 @@ def test_missing_subclass():
     with pytest.raises(McsUserError, match=r'No subclass of PostProcessor .*'):
         PostProcessor.load_plugin(path)
 
+@pytest.mark.skip()
 def test_cmd_line_post_proc(opgee_main):
     PostProcessor.decache()
     plugin_path = path_to_test_file('simple_post_processor.py')
@@ -126,6 +127,7 @@ def test_auto_loading(opgee_main):
             csv_file = os.path.join(output_dir, f'auto_loaded_post_proc_{i}.csv')
             assert os.path.exists(csv_file)
 
+@pytest.mark.skip()
 def test_no_auto_loading(opgee_main):
     from opgee.config import setParam
     PostProcessor.decache()

--- a/tests/test_run_subcmd.py
+++ b/tests/test_run_subcmd.py
@@ -3,8 +3,14 @@ import os
 import pytest
 from opgee.config import setParam, pathjoin
 from opgee.error import CommandlineError
+from opgee.post_processor import PostProcessor
 from opgee.tool import opg
 from .utils_for_tests import path_to_test_file, tempdir
+
+@pytest.fixture(autouse=True)
+def decache_post_plugins():
+    PostProcessor.decache()
+    yield
 
 def test_missing_output_dir(opgee_main):
     name = 'test'


### PR DESCRIPTION
Fixes #57.
___

Change Summary
* move post processor plugin registration & loading into parent class
* ensure only one instance of a given plugin class is registered
* remove cli args related to post processing plugins
  * TODO: refactor config & cli args to merge in to single config object that can be passed to workers
* use `dask.distributed.SubprocessCluster` (experimental) for running workers in dedicated subprocesses
  * small naming update to align with `dask` arguments
* a couple small process fixes
* decache the post processor plugins in tests (registration/loading was persisted across tests)