### PR TITLE
Fixed WaterTreatment

### DIFF
--- a/opgee/etc/opgee.xml
+++ b/opgee/etc/opgee.xml
@@ -409,9 +409,8 @@
 		</Stream>
 
 
-		<!--		water processing path-->
+		<!-- water processing path-->
 		<Stream src="WaterTreatment" dst="ProductionBoundary">
-			<Contains>water</Contains>
 			<Contains>water for subsurface disposal</Contains>
 		</Stream>
 

--- a/opgee/process.py
+++ b/opgee/process.py
@@ -666,7 +666,7 @@ class Process(AttributeMixin, XmlInstantiable):
         streams = self.find_output_streams(stream_type, as_list=True, regex=regex, raiseError=raiseError)
         if len(streams) != 1:
             if raiseError:
-                raise OpgeeException(f"Expected one output stream with '{stream_type}'; found {len(streams)}")
+                raise OpgeeException(f"{self}: Expected one output stream with '{stream_type}'; found {len(streams)}")
             return None
 
         stream = streams[0]


### PR DESCRIPTION
I've been working with one of Adam's grad students, Spencer Zhang, who is going to add H2 production to the model. We used `csv2xml` to generate an XML file and tried to run it, but it failed in validation for the `WaterTreatment` process. 

This pull request fixes the problem in `opgee.xml` and adds info to an exception to help diagnose validation failure.

Note that this issue wasn't surfaced by the test suite, so improving that would be helpful.
